### PR TITLE
Fix env vars

### DIFF
--- a/charts/replicated-library/README.md
+++ b/charts/replicated-library/README.md
@@ -56,7 +56,7 @@ Read through the [values.yaml](./values.yaml) file. It has several commented out
 | apps.example.automountServiceAccountToken | bool | `true` | Specifies whether a service account token should be automatically mounted. |
 | apps.example.containers.example.args | list | `[]` | Override the arguments for the container |
 | apps.example.containers.example.command | list | `[]` | Override the command for the container |
-| apps.example.containers.example.env | string | `nil` | Environment variables. Template enabled. Syntax options: A) TZ: UTC B) PASSWD: '{{ .Release.Name }}' C) PASSWD:      configMapKeyRef:        name: config-map-name        key: key-name D) PASSWD:      valueFrom:        secretKeyRef:          name: secret-name          key: key-name      ... E) - name: TZ      value: UTC F) - name: TZ      value: '{{ .Release.Name }}' |
+| apps.example.containers.example.env | string | `nil` | Environment variables. Template enabled. Syntax options: A) TZ: UTC |
 | apps.example.containers.example.envFrom | list | `[]` | Secrets and/or ConfigMaps that will be loaded as environment variables. [[ref]](https://unofficial-kubernetes.readthedocs.io/en/latest/tasks/configure-pod-container/configmap/#use-case-consume-configmap-in-environment-variables) |
 | apps.example.containers.example.image.pullPolicy | string | `nil` | Specify the image pull policy for the container |
 | apps.example.containers.example.image.repository | string | `"nginx"` | Specify the image repository for the container |

--- a/charts/replicated-library/templates/lib/app/_container.tpl
+++ b/charts/replicated-library/templates/lib/app/_container.tpl
@@ -44,7 +44,7 @@
 {{- end }}
   {{- with $containerValues.env }}
   env:
-    {{- get (fromYaml (include "replicated-library.env_vars" $)) "env" | toYaml | nindent 4 -}}
+    {{- get (fromYaml (include "replicated-library.env_vars" .)) "env" | toYaml | nindent 4 -}}
   {{- end }}
   {{- if or $containerValues.envFrom $containerValues.secret }}
   envFrom:

--- a/charts/replicated-library/templates/lib/app/_env_vars.tpl
+++ b/charts/replicated-library/templates/lib/app/_env_vars.tpl
@@ -3,11 +3,6 @@ Environment variables used by containers.
 */}}
 {{- define "replicated-library.env_vars" -}}
   {{- $values := . -}}
-  {{- if hasKey . "AppValues" -}}
-    {{- with .AppValues.app -}}
-      {{- $values = .env -}}
-    {{- end -}}
-  {{ end -}}
 
   {{- with $values -}}
     {{- $result := list -}}
@@ -18,24 +13,12 @@ Environment variables used by containers.
         {{- $name = required "environment variables as a list of maps require a name field" $value.name -}}
       {{- end -}}
 
-      {{- if kindIs "map" $value -}}
-        {{- if hasKey $value "value" -}}
-          {{- $envValue := $value.value | toString -}}
-          {{- $result = append $result (dict "name" $name "value" (tpl $envValue $)) -}}
-        {{- else if hasKey $value "valueFrom" -}}
-          {{- $result = append $result (dict "name" $name "valueFrom" $value.valueFrom) -}}
-        {{- else -}}
-          {{- $result = append $result (dict "name" $name "valueFrom" $value) -}}
-        {{- end -}}
-      {{- end -}}
-      {{- if not (kindIs "map" $value) -}}
-        {{- if kindIs "string" $value -}}
-          {{- $result = append $result (dict "name" $name "value" (tpl $value $)) -}}
-        {{- else if or (kindIs "float64" $value) (kindIs "bool" $value) -}}
-          {{- $result = append $result (dict "name" $name "value" ($value | toString)) -}}
-        {{- else -}}
-          {{- $result = append $result (dict "name" $name "value" $value) -}}
-        {{- end -}}
+      {{- if kindIs "string" $value -}}
+        {{- $result = append $result (dict "name" $name "value" $value) -}}
+      {{- else if or (kindIs "float64" $value) (kindIs "bool" $value) -}}
+        {{- $result = append $result (dict "name" $name "value" ($value | toString)) -}}
+      {{- else -}}
+        {{- $result = append $result (dict "name" $name "value" $value) -}}
       {{- end -}}
     {{- end -}}
     {{- toYaml (dict "env" $result) | nindent 0 -}}

--- a/charts/replicated-library/values.yaml
+++ b/charts/replicated-library/values.yaml
@@ -51,21 +51,6 @@ apps:
         # -- Environment variables. Template enabled.
         # Syntax options:
         # A) TZ: UTC
-        # B) PASSWD: '{{ .Release.Name }}'
-        # C) PASSWD:
-        #      configMapKeyRef:
-        #        name: config-map-name
-        #        key: key-name
-        # D) PASSWD:
-        #      valueFrom:
-        #        secretKeyRef:
-        #          name: secret-name
-        #          key: key-name
-        #      ...
-        # E) - name: TZ
-        #      value: UTC
-        # F) - name: TZ
-        #      value: '{{ .Release.Name }}'
         env:
 
         # -- Secrets and/or ConfigMaps that will be loaded as environment variables.


### PR DESCRIPTION
Fixing the `env` property for containers

Supported syntax will be
```
...
env: 
  TZ: UTC
...
```