### PR TITLE
Default liveness and readiness probes if not defined

### DIFF
--- a/charts/replicated-library/templates/lib/_container.tpl
+++ b/charts/replicated-library/templates/lib/_container.tpl
@@ -70,7 +70,7 @@
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- else if hasKey $containerValues "livenessProbe" -}}
-  {{- else if (first $containerValues.ports).containerPort -}}
+  {{- else if and $containerValues.ports (first $containerValues.ports).containerPort -}}
   {{- $_ := set $.Values.defaults.probes.livenessProbe "tcpSocket" (dict "port" (first $containerValues.ports).containerPort) }}
   {{- with $.Values.defaults.probes.livenessProbe }}
   livenessProbe:
@@ -83,7 +83,7 @@
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- else if hasKey $containerValues "readinessProbe" -}}
-  {{- else if (first $containerValues.ports).containerPort -}}
+  {{- else if and $containerValues.ports (first $containerValues.ports).containerPort -}}
   {{- $_ := set $.Values.defaults.probes.readinessProbe "tcpSocket" (dict "port" (first $containerValues.ports).containerPort) }}
   {{- with $.Values.defaults.probes.readinessProbe }}
   readinessProbe:

--- a/charts/replicated-library/templates/lib/_container.tpl
+++ b/charts/replicated-library/templates/lib/_container.tpl
@@ -64,25 +64,37 @@
   resources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- if $containerValues.probes -}}
-  {{- if $containerValues.probes.livenessProbe -}}
-  {{- with (mergeOverwrite $.Values.defaults.probes.livenessProbe $containerValues.probes.livenessProbe) }}
+  {{- if $containerValues.livenessProbe -}}
+  {{- with (mergeOverwrite $.Values.defaults.probes.livenessProbe $containerValues.livenessProbe) }}
   livenessProbe:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- else if hasKey $containerValues "livenessProbe" -}}
+  {{- else if (first $containerValues.ports).containerPort -}}
+  {{- $_ := set $.Values.defaults.probes.livenessProbe "tcpSocket" (dict "port" (first $containerValues.ports).containerPort) }}
+  {{- with $.Values.defaults.probes.livenessProbe }}
+  livenessProbe:
+    {{- toYaml . | nindent 4 }}
   {{- end -}}
-  {{- if $containerValues.probes.readinessProbe -}}
-  {{- with (mergeOverwrite $.Values.defaults.probes.readinessProbe $containerValues.probes.readinessProbe) }}
+  {{- end -}}
+  {{- if $containerValues.readinessProbe -}}
+  {{- with (mergeOverwrite $.Values.defaults.probes.readinessProbe $containerValues.readinessProbe) }}
   readinessProbe:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- else if hasKey $containerValues "readinessProbe" -}}
+  {{- else if (first $containerValues.ports).containerPort -}}
+  {{- $_ := set $.Values.defaults.probes.readinessProbe "tcpSocket" (dict "port" (first $containerValues.ports).containerPort) }}
+  {{- with $.Values.defaults.probes.readinessProbe }}
+  readinessProbe:
+    {{- toYaml . | nindent 4 }}
   {{- end -}}
-  {{- if $containerValues.probes.startupProbe -}}
-  {{- with (mergeOverwrite $.Values.defaults.probes.startupProbe $containerValues.probes.startupProbe) }}
+  {{- end -}}
+  {{- if $containerValues.startupProbe -}}
+  {{- with (mergeOverwrite $.Values.defaults.probes.startupProbe $containerValues.startupProbe) }}
   startupProbe:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end -}}
-{{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
This implements suggestions from #23.

* Probes are moved from container.probes to be directly defined on the container object like the other container values.
* Liveness and Readiness probes will now default to a tcpSocket of the first port on the container if ports are defined
  * Defining either probe as {} disables generation, overrides can be done same as before