### PR TITLE
Dynamic object names per release

### DIFF
--- a/charts/replicated-library/README.md
+++ b/charts/replicated-library/README.md
@@ -80,6 +80,7 @@ Read through the [values.yaml](./values.yaml) file. It has several commented out
 | apps.example.dnsPolicy | string | `nil` | Defaults to "ClusterFirst" if hostNetwork is false and "ClusterFirstWithHostNet" if hostNetwork is true. |
 | apps.example.enableServiceLinks | bool | `true` | Enable/disable the generation of environment variables for services. [[ref]](https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#accessing-the-service) |
 | apps.example.enabled | bool | `false` | Enable the app Each app represents a single controller type (deployment, daemonset, statefulset) |
+| apps.example.fullNameOverride | string | `nil` | Override the name of this object. Default name if not overwritten will be releaseName-ChartName-objectName |
 | apps.example.hostAliases | list | `[]` | Use hostAliases to add custom entries to /etc/hosts - mapping IP addresses to hostnames. [[ref]](https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/) |
 | apps.example.hostNetwork | bool | `false` | When using hostNetwork make sure you set dnsPolicy to `ClusterFirstWithHostNet` |
 | apps.example.hostname | string | `nil` | Allows specifying explicit hostname setting |
@@ -112,8 +113,8 @@ Read through the [values.yaml](./values.yaml) file. It has several commented out
 | configmaps.exampleConfig.annotations | object | `{}` | Annotations to add to the configMap |
 | configmaps.exampleConfig.data | object | `{}` | configMap data content. Helm template enabled. |
 | configmaps.exampleConfig.enabled | bool | `false` | Enables or disables the configMap |
+| configmaps.exampleConfig.fullNameOverride | string | `nil` | Override the name of this object. Default name if not overwritten will be releaseName-ChartName-objectName |
 | configmaps.exampleConfig.labels | object | `{}` | Labels to add to the configMap |
-| configmaps.exampleConfig.nameOverride | string | `nil` | Override the name suffix that is used for this configap |
 | defaults.image.pullPolicy | string | `"IfNotPresent"` |  |
 | defaults.probes.livenessProbe.failureThreshold | int | `5` |  |
 | defaults.probes.livenessProbe.initialDelaySeconds | int | `0` |  |
@@ -129,19 +130,21 @@ Read through the [values.yaml](./values.yaml) file. It has several commented out
 | defaults.probes.startupProbe | object | `{}` |  |
 | defaults.strategy | string | `"RollingUpdate"` |  |
 | global.annotations | object | `{}` | Set additional global annotations. |
+| global.fullnameOverride | string | `nil` | Set the entire name definition |
 | global.labels | object | `{}` | Set additional global labels. |
+| global.nameOverride | string | `nil` | Set an override for the prefix of the fullname |
 | ingresses | object | See below | Configure the ingresses for the chart here. Ingresses can be added by adding a dictionary key similar to the 'example' ingress. Name of the ingress object will be the name of the dictionary key |
 | ingresses.example.annotations | object | `{}` | Provide additional annotations which may be required. |
 | ingresses.example.enabled | bool | `false` | Enables or disables the ingress |
+| ingresses.example.fullNameOverride | string | `nil` | Override the name of this object. Default name if not overwritten will be releaseName-ChartName-objectName |
 | ingresses.example.hosts | list | `[{"host":"chart-example.local","paths":[{"path":"/","pathType":"Prefix","service":{"name":null,"port":null}}]}]` | Configure the hosts for the ingress |
 | ingresses.example.hosts[0].paths[0].service.name | string | `nil` | Service Name for the path. By default this is ingresses.example.serviceName if not overwritten TODO: NOT IMPLEMENTED |
 | ingresses.example.ingressClassName | string | `nil` | Set the ingressClass that is used for this ingress. Requires Kubernetes >=1.19 |
 | ingresses.example.labels | object | `{}` | Provide additional labels which may be required. |
-| ingresses.example.nameOverride | string | `nil` | Override the name that is used for this ingress. By default the name will be the name of the dictionary key |
 | ingresses.example.serviceName | string | `"example"` | Name of the service to attach this ingress. This corresponds to an service configured un the `services` key |
 | persistence | object | See below | Configure volumes for the chart here. Persistence items can be added by adding a dictionary key similar to the 'example' key. Name of the persistence object will be the name of the dictionary key unless overwritten with persistence.*.nameOverride |
 | persistence.example.enabled | bool | `false` | Enables or disables the volume |
-| persistence.example.nameOverride | string | `nil` | Override the name that is used for this persistence object TODO: NOT IMPLEMENTED |
+| persistence.example.fullNameOverride | string | `nil` | Override the name of this object. Default name if not overwritten will be releaseName-ChartName-objectName |
 | persistence.example.persistentVolume | object | `{"spec":{"accessModes":["ReadWriteOnce"],"capacity":{"storage":"1Gi"},"hostPath":{"path":"/tmp/data1"},"reclaimPolicy":["Recycle"]}}` | Configure a persistentVolume and persistentVolumeClaim pair to be mounted to the app's primary container TODO: Not implemented |
 | persistence.example.persistentVolume.spec | object | `{"accessModes":["ReadWriteOnce"],"capacity":{"storage":"1Gi"},"hostPath":{"path":"/tmp/data1"},"reclaimPolicy":["Recycle"]}` | PersistentVolumeClaim spec [[ref]](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) |
 | persistence.example.persistentVolumeClaim | object | `{"existingClaimName":null,"spec":{"accessModes":["ReadWriteOnce"],"persistentVolumeReclaimPolicy":"Retain","resources":{"requests":{"storage":"8Gi"}},"storageClassName":"slow","volumeMode":"Filesystem"}}` | Configure a Persistent Volume Claim to be mounted to the app's primary container |
@@ -152,18 +155,18 @@ Read through the [values.yaml](./values.yaml) file. It has several commented out
 | secrets.exampleSecret.annotations | object | `{}` | Annotations to add to the secret |
 | secrets.exampleSecret.data | object | `{}` | configMap data content. Helm template enabled. |
 | secrets.exampleSecret.enabled | bool | `false` | Enables or disables the secret |
+| secrets.exampleSecret.fullNameOverride | string | `nil` | Override the name of this object. Default name if not overwritten will be releaseName-ChartName-objectName |
 | secrets.exampleSecret.labels | object | `{}` | Labels to add to the secret |
-| secrets.exampleSecret.nameOverride | string | `nil` | Override the name suffix that is used for this secret |
 | services | object | See below | Configure the services for the chart here. Services can be added by adding a dictionary key similar to the 'example' service. By default the name of the service will be the name of the dictionary key TODO: nameOverride |
 | services.example.annotations | object | `{}` | Provide additional annotations which may be required. |
 | services.example.appName | string | `"example"` | Name of the app to attach this service. This corresponds to an app configured un the `apps` key TODO: Accept a list of appnames of which to associate the service TODO: Needs to be optional |
 | services.example.clusterIP | string | `nil` | Set the clusterIP |
 | services.example.enabled | bool | `false` | Enables or disables the service |
 | services.example.externalTrafficPolicy | string | `nil` | [[ref](https://kubernetes.io/docs/tutorials/services/source-ip/)] |
+| services.example.fullNameOverride | string | `nil` | Override the name of this object. Default name if not overwritten will be releaseName-ChartName-objectName |
 | services.example.ipFamilies | list | `[]` | The ip families that should be used. Options: IPv4, IPv6 |
 | services.example.ipFamilyPolicy | string | `nil` | Specify the ip policy. Options: SingleStack, PreferDualStack, RequireDualStack |
 | services.example.labels | object | `{}` | Provide additional labels which may be required. |
-| services.example.nameOverride | string | `nil` | Override the name suffix that is used for this service |
 | services.example.ports | object | See below | Configure the Service port information here. Additional ports can be added by adding a dictionary key similar to the 'http' service. |
 | services.example.ports.http.enabled | bool | `true` | Enables or disables the port |
 | services.example.ports.http.nodePort | string | `nil` | Specify the nodePort value for the LoadBalancer and NodePort service types. [[ref]](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport) |

--- a/charts/replicated-library/templates/_all.tpl
+++ b/charts/replicated-library/templates/_all.tpl
@@ -20,8 +20,8 @@ Main entrypoint for the replicated-library chart. It will render all underlying 
     {{- if $app.enabled -}}
       {{- $appValues := $app -}}
 
-      {{- $_ := set $ "AppName" $name -}}
-      {{- $_ := set $ "AppValues" (dict "app" $appValues) -}}
+      {{- $_ := set $ "ObjectName" $name -}}
+      {{- $_ := set $ "ObjectValues" (dict "values" $appValues) -}}
 
       {{- if eq $appValues.type "deployment" }}
         {{- include "replicated-library.deployment" $ | nindent 0 }}

--- a/charts/replicated-library/templates/classes/_configmap.tpl
+++ b/charts/replicated-library/templates/classes/_configmap.tpl
@@ -11,7 +11,7 @@ within the replicated-library library.
   {{ end -}}
 
   {{- if hasKey . "ObjectValues" -}}
-    {{- with .ObjectValues.configmap -}}
+    {{- with .ObjectValues.values -}}
       {{- $values = . -}}
     {{- end -}}
   {{ end -}}
@@ -19,7 +19,7 @@ within the replicated-library library.
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ $configMapName }}
+  name: {{ printf "%s-%s" (include "replicated-library.names.fullname") $configMapName | trunc 63 | trimSuffix "-" }}
   {{- with (merge ($values.labels | default dict) (include "replicated-library.labels" $ | fromYaml)) }}
   labels: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/replicated-library/templates/classes/_configmap.tpl
+++ b/charts/replicated-library/templates/classes/_configmap.tpl
@@ -19,7 +19,7 @@ within the replicated-library library.
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ printf "%s-%s" (include "replicated-library.names.fullname") $configMapName | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s" (include "replicated-library.names.fullname" .) $configMapName | trunc 63 | trimSuffix "-" }}
   {{- with (merge ($values.labels | default dict) (include "replicated-library.labels" $ | fromYaml)) }}
   labels: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/replicated-library/templates/classes/_configmap.tpl
+++ b/charts/replicated-library/templates/classes/_configmap.tpl
@@ -19,7 +19,7 @@ within the replicated-library library.
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ printf "%s-%s" (include "replicated-library.names.fullname" .) $configMapName | trunc 63 | trimSuffix "-" }}
+  name: {{ include "replicated-library.names.fullname" . }}
   {{- with (merge ($values.labels | default dict) (include "replicated-library.labels" $ | fromYaml)) }}
   labels: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/replicated-library/templates/classes/_ingress.tpl
+++ b/charts/replicated-library/templates/classes/_ingress.tpl
@@ -23,7 +23,7 @@ within the replicated-library library.
 apiVersion: {{ include "replicated-library.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-  name: {{ printf "%s-%s" (include "replicated-library.names.fullname" .) $ingressName | trunc 63 | trimSuffix "-" }}
+  name: {{ include "replicated-library.names.fullname" . }}
   {{- with (merge ($values.labels | default dict) (include "replicated-library.labels" $ | fromYaml)) }}
   labels: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/replicated-library/templates/classes/_ingress.tpl
+++ b/charts/replicated-library/templates/classes/_ingress.tpl
@@ -23,7 +23,7 @@ within the replicated-library library.
 apiVersion: {{ include "replicated-library.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-  name: {{ printf "%s-%s" (include "replicated-library.names.fullname") $ingressName | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s" (include "replicated-library.names.fullname" .) $ingressName | trunc 63 | trimSuffix "-" }}
   {{- with (merge ($values.labels | default dict) (include "replicated-library.labels" $ | fromYaml)) }}
   labels: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/replicated-library/templates/classes/_ingress.tpl
+++ b/charts/replicated-library/templates/classes/_ingress.tpl
@@ -11,7 +11,7 @@ within the replicated-library library.
   {{ end -}}
 
   {{- if hasKey . "ObjectValues" -}}
-    {{- with .ObjectValues.ingress -}}
+    {{- with .ObjectValues.values -}}
       {{- $values = . -}}
     {{- end -}}
   {{ end -}}
@@ -23,7 +23,7 @@ within the replicated-library library.
 apiVersion: {{ include "replicated-library.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-  name: {{ $ingressName }}
+  name: {{ printf "%s-%s" (include "replicated-library.names.fullname") $ingressName | trunc 63 | trimSuffix "-" }}
   {{- with (merge ($values.labels | default dict) (include "replicated-library.labels" $ | fromYaml)) }}
   labels: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/replicated-library/templates/classes/_pvc.tpl
+++ b/charts/replicated-library/templates/classes/_pvc.tpl
@@ -25,7 +25,7 @@ within the replicated-library library.
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ printf "%s-%s" (include "replicated-library.names.fullname" .) $pvcName | trunc 63 | trimSuffix "-" }}
+  name: {{ include "replicated-library.names.fullname" . }}
   {{- with (merge ($values.labels | default dict) (include "replicated-library.labels" $ | fromYaml)) }}
   labels: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/replicated-library/templates/classes/_pvc.tpl
+++ b/charts/replicated-library/templates/classes/_pvc.tpl
@@ -25,7 +25,7 @@ within the replicated-library library.
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ printf "%s-%s" (include "replicated-library.names.fullname") $pvcName | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s" (include "replicated-library.names.fullname" .) $pvcName | trunc 63 | trimSuffix "-" }}
   {{- with (merge ($values.labels | default dict) (include "replicated-library.labels" $ | fromYaml)) }}
   labels: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/replicated-library/templates/classes/_pvc.tpl
+++ b/charts/replicated-library/templates/classes/_pvc.tpl
@@ -11,7 +11,7 @@ within the replicated-library library.
   {{ end -}}
 
   {{- if hasKey . "ObjectValues" -}}
-    {{- with .ObjectValues.persistence -}}
+    {{- with .ObjectValues.values -}}
       {{- $values = . -}}
     {{- end -}}
   {{ end -}}
@@ -25,7 +25,7 @@ within the replicated-library library.
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ $pvcName }}
+  name: {{ printf "%s-%s" (include "replicated-library.names.fullname") $pvcName | trunc 63 | trimSuffix "-" }}
   {{- with (merge ($values.labels | default dict) (include "replicated-library.labels" $ | fromYaml)) }}
   labels: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/replicated-library/templates/classes/_secret.tpl
+++ b/charts/replicated-library/templates/classes/_secret.tpl
@@ -19,7 +19,7 @@ within the replicated-library library.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-%s" (include "replicated-library.names.fullname") $secretName | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s" (include "replicated-library.names.fullname" .) $secretName | trunc 63 | trimSuffix "-" }}
   {{- with (merge ($values.labels | default dict) (include "replicated-library.labels" $ | fromYaml)) }}
   labels: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/replicated-library/templates/classes/_secret.tpl
+++ b/charts/replicated-library/templates/classes/_secret.tpl
@@ -19,7 +19,7 @@ within the replicated-library library.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-%s" (include "replicated-library.names.fullname" .) $secretName | trunc 63 | trimSuffix "-" }}
+  name: {{ include "replicated-library.names.fullname" . }}
   {{- with (merge ($values.labels | default dict) (include "replicated-library.labels" $ | fromYaml)) }}
   labels: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/replicated-library/templates/classes/_secret.tpl
+++ b/charts/replicated-library/templates/classes/_secret.tpl
@@ -11,7 +11,7 @@ within the replicated-library library.
   {{ end -}}
 
   {{- if hasKey . "ObjectValues" -}}
-    {{- with .ObjectValues.secret -}}
+    {{- with .ObjectValues.values -}}
       {{- $values = . -}}
     {{- end -}}
   {{ end -}}
@@ -19,7 +19,7 @@ within the replicated-library library.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $secretName }}
+  name: {{ printf "%s-%s" (include "replicated-library.names.fullname") $secretName | trunc 63 | trimSuffix "-" }}
   {{- with (merge ($values.labels | default dict) (include "replicated-library.labels" $ | fromYaml)) }}
   labels: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/replicated-library/templates/classes/_service.tpl
+++ b/charts/replicated-library/templates/classes/_service.tpl
@@ -21,7 +21,7 @@ within the replicated-library library.
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-%s" (include "replicated-library.names.fullname") $serviceName | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s" (include "replicated-library.names.fullname" .) $serviceName | trunc 63 | trimSuffix "-" }}
   {{- with (merge ($values.labels | default dict) (include "replicated-library.labels" $ | fromYaml)) }}
   labels: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/replicated-library/templates/classes/_service.tpl
+++ b/charts/replicated-library/templates/classes/_service.tpl
@@ -11,7 +11,7 @@ within the replicated-library library.
   {{ end -}}
 
   {{- if hasKey . "ObjectValues" -}}
-    {{- with .ObjectValues.service -}}
+    {{- with .ObjectValues.values -}}
       {{- $values = . -}}
     {{- end -}}
   {{ end -}}
@@ -21,7 +21,7 @@ within the replicated-library library.
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $serviceName }}
+  name: {{ printf "%s-%s" (include "replicated-library.names.fullname") $serviceName | trunc 63 | trimSuffix "-" }}
   {{- with (merge ($values.labels | default dict) (include "replicated-library.labels" $ | fromYaml)) }}
   labels: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/replicated-library/templates/classes/_service.tpl
+++ b/charts/replicated-library/templates/classes/_service.tpl
@@ -15,13 +15,13 @@ within the replicated-library library.
       {{- $values = . -}}
     {{- end -}}
   {{ end -}}
-  
+
   {{- $svcType := $values.type | default "" -}}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-%s" (include "replicated-library.names.fullname" .) $serviceName | trunc 63 | trimSuffix "-" }}
+  name: {{ include "replicated-library.names.fullname" . }}
   {{- with (merge ($values.labels | default dict) (include "replicated-library.labels" $ | fromYaml)) }}
   labels: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/replicated-library/templates/lib/_configmap.tpl
+++ b/charts/replicated-library/templates/lib/_configmap.tpl
@@ -12,7 +12,7 @@ Renders the configmap objects required by the chart.
         {{- $_ := set $ "ObjectName" $configmapValues.nameOverride -}}
       {{ end -}}
 
-      {{- $_ := set $ "ObjectValues" (dict "configmap" $configmapValues) -}}
+      {{- $_ := set $ "ObjectValues" (dict "values" $configmapValues) -}}
 
       {{- include "replicated-library.classes.configmap" $ | nindent 0 }}
     {{- end }}

--- a/charts/replicated-library/templates/lib/_container.tpl
+++ b/charts/replicated-library/templates/lib/_container.tpl
@@ -1,8 +1,8 @@
 {{- /* The main container included in the main */ -}}
 {{- define "replicated-library.container" -}}
   {{- $values := . -}}
-  {{- if hasKey . "AppValues" -}}
-    {{- with .AppValues.app -}}
+  {{- if hasKey . "ObjectValues" -}}
+    {{- with .ObjectValues.values -}}
       {{- $values = . -}}
     {{- end -}}
   {{ end -}}

--- a/charts/replicated-library/templates/lib/_deployment.tpl
+++ b/charts/replicated-library/templates/lib/_deployment.tpl
@@ -3,9 +3,14 @@ This template serves as the blueprint for the Deployment objects that are create
 within the replicated-library library.
 */}}
 {{- define "replicated-library.deployment" }}
+  {{- $name := .Values.global.nameOverride -}}
+  {{- if hasKey . "ObjectName" -}}
+    {{- $name = .ObjectName -}}
+  {{ end -}}
+
   {{- $values := . -}}
-  {{- if hasKey . "AppValues" -}}
-    {{- with .AppValues.app -}}
+  {{- if hasKey . "ObjectValues" -}}
+    {{- with .ObjectValues.values -}}
       {{- $values = . -}}
     {{- end -}}
   {{ end -}}
@@ -13,7 +18,7 @@ within the replicated-library library.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "replicated-library.names.appname" . }}
+  name: {{ printf "%s-%s" (include "replicated-library.names.fullname") $name | trunc 63 | trimSuffix "-" }}
   {{- with (merge ($values.labels | default dict) (include "replicated-library.labels" $ | fromYaml)) }}
   labels: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/replicated-library/templates/lib/_deployment.tpl
+++ b/charts/replicated-library/templates/lib/_deployment.tpl
@@ -18,7 +18,7 @@ within the replicated-library library.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ printf "%s-%s" (include "replicated-library.names.fullname" .) $name | trunc 63 | trimSuffix "-" }}
+  name: {{ include "replicated-library.names.fullname" . }}
   {{- with (merge ($values.labels | default dict) (include "replicated-library.labels" $ | fromYaml)) }}
   labels: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/replicated-library/templates/lib/_deployment.tpl
+++ b/charts/replicated-library/templates/lib/_deployment.tpl
@@ -18,7 +18,7 @@ within the replicated-library library.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ printf "%s-%s" (include "replicated-library.names.fullname") $name | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s" (include "replicated-library.names.fullname" .) $name | trunc 63 | trimSuffix "-" }}
   {{- with (merge ($values.labels | default dict) (include "replicated-library.labels" $ | fromYaml)) }}
   labels: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/replicated-library/templates/lib/_ingress.tpl
+++ b/charts/replicated-library/templates/lib/_ingress.tpl
@@ -12,7 +12,7 @@ Renders the Service objects required by the chart.
         {{- $_ := set $ "ObjectName" $ingressValues.nameOverride -}}
       {{ end -}}
 
-      {{- $_ := set $ "ObjectValues" (dict "ingress" $ingressValues) -}}
+      {{- $_ := set $ "ObjectValues" (dict "values" $ingressValues) -}}
 
       {{- if $ingress.serviceName }}
         {{- $matchingAppFound := false -}}

--- a/charts/replicated-library/templates/lib/_labels.tpl
+++ b/charts/replicated-library/templates/lib/_labels.tpl
@@ -25,7 +25,7 @@ app.kubernetes.io/appname: {{ include "replicated-library.names.appname" . }}
   {{- $serviceValues := . -}}
 
   {{- if hasKey . "ObjectValues" -}}
-    {{- with .ObjectValues.service -}}
+    {{- with .ObjectValues.values -}}
       {{- $serviceValues = . -}}
     {{- end -}}
   {{ end -}}
@@ -45,7 +45,7 @@ app.kubernetes.io/appname: {{ $appName }}
     {{- end }}
   
   {{- else }}
-app.kubernetes.io/appname: {{- include "replicated-library.names.fullname" -}}
+app.kubernetes.io/appname: {{- include "replicated-library.names.fullname" . -}}
   {{- end }}
 
 {{- end -}}

--- a/charts/replicated-library/templates/lib/_names.tpl
+++ b/charts/replicated-library/templates/lib/_names.tpl
@@ -20,8 +20,8 @@ If release name contains chart name it will be used as a full name.
     {{- end -}}
   {{- end -}}
 
-  {{- if $values.nameOverride -}}
-    {{- trunc 63 $values.nameOverride | trimSuffix "-" -}}
+  {{- if $values.fullNameOverride -}}
+    {{- trunc 63 $values.fullNameOverride | trimSuffix "-" -}}
   {{- else -}}
     {{- $name := include "replicated-library.names.name" . -}}
     {{- $globalFullNameOverride := "" -}}

--- a/charts/replicated-library/templates/lib/_names.tpl
+++ b/charts/replicated-library/templates/lib/_names.tpl
@@ -30,7 +30,7 @@ If release name contains chart name it will be used as a full name.
   {{- else -}}
     {{- $name := include "replicated-library.names.name" . -}}
     {{- if .Values.global.fullNameOverride -}}
-      {{- $name = .Values.global.fullnameOverride -}}
+      {{- $name = .Values.global.fullNameOverride -}}
     {{- else if contains $name .Release.Name -}}
       {{- $name = .Release.Name -}}
     {{- else -}}

--- a/charts/replicated-library/templates/lib/_names.tpl
+++ b/charts/replicated-library/templates/lib/_names.tpl
@@ -13,6 +13,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "replicated-library.names.fullname" -}}
+  {{- $objectName := "" -}}
+  {{- if hasKey . "ObjectName" -}}
+    {{- $objectName = .ObjectName -}}
+  {{- end -}}
+
   {{- $values := . -}}
   {{- if hasKey . "ObjectValues" -}}
     {{- with .ObjectValues.values -}}
@@ -31,7 +36,7 @@ If release name contains chart name it will be used as a full name.
     {{- else -}}
       {{- $name = printf "%s-%s" .Release.Name $name -}}
     {{- end -}}
-    {{- trunc 63 $name | trimSuffix "-" -}}
+    {{- printf "%s-%s" $name $objectName | trunc 63 | trimSuffix "-" -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/replicated-library/templates/lib/_names.tpl
+++ b/charts/replicated-library/templates/lib/_names.tpl
@@ -4,7 +4,7 @@
   {{- if hasKey .Values "global" -}}
     {{- $globalNameOverride = (default $globalNameOverride .Values.global.nameOverride) -}}
   {{- end -}}
-  {{- default .Chart.Name (default .Values.nameOverride $globalNameOverride) | trunc 63 | trimSuffix "-" -}}
+  {{- default .Chart.Name (default "" $globalNameOverride) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -13,21 +13,28 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "replicated-library.names.fullname" -}}
-  {{- $name := include "replicated-library.names.name" . -}}
-  {{- $globalFullNameOverride := "" -}}
-  {{- if hasKey .Values "global" -}}
-    {{- $globalFullNameOverride = (default $globalFullNameOverride .Values.global.fullnameOverride) -}}
-  {{- end -}}
-  {{- if or .Values.fullnameOverride $globalFullNameOverride -}}
-    {{- $name = default .Values.fullnameOverride $globalFullNameOverride -}}
+  {{- $values := . -}}
+  {{- if hasKey . "ObjectValues" -}}
+    {{- with .ObjectValues.values -}}
+      {{- $values = . -}}
+    {{- end -}}
+  {{ end -}}
+
+  {{- if $values.nameOverride -}}
+    {{- trunc 63 $values.nameOverride | trimSuffix "-" -}}
   {{- else -}}
+    {{- $name := include "replicated-library.names.name" . -}}
+    {{- $globalFullNameOverride := "" -}}
+    {{- if hasKey .Values "global" -}}
+      {{- $globalFullNameOverride = (default $globalFullNameOverride .Values.global.fullnameOverride) -}}
+    {{- end -}}
     {{- if contains $name .Release.Name -}}
       {{- $name = .Release.Name -}}
     {{- else -}}
       {{- $name = printf "%s-%s" .Release.Name $name -}}
     {{- end -}}
+    {{- trunc 63 $name | trimSuffix "-" -}}
   {{- end -}}
-  {{- trunc 63 $name | trimSuffix "-" -}}
 {{- end -}}
 
 {{/* Create chart name and version as used by the chart label */}}
@@ -39,12 +46,12 @@ If release name contains chart name it will be used as a full name.
 {{- define "replicated-library.names.serviceAccountName" -}}
   {{- $name := "default" }}
   {{- $values := .Values.serviceAccount -}}
-  {{- if hasKey . "AppName" -}}
-    {{- $name = .AppName -}}
+  {{- if hasKey . "ObjectName" -}}
+    {{- $name = .ObjectName -}}
   {{ end -}}
 
-  {{- if hasKey . "AppValues" -}}
-    {{- with .AppValues.app -}}
+  {{- if hasKey . "ObjectValues" -}}
+    {{- with .ObjectValues.app -}}
       {{- $values = . -}}
     {{- end -}}
   {{ end -}}

--- a/charts/replicated-library/templates/lib/_names.tpl
+++ b/charts/replicated-library/templates/lib/_names.tpl
@@ -24,11 +24,9 @@ If release name contains chart name it will be used as a full name.
     {{- trunc 63 $values.fullNameOverride | trimSuffix "-" -}}
   {{- else -}}
     {{- $name := include "replicated-library.names.name" . -}}
-    {{- $globalFullNameOverride := "" -}}
-    {{- if hasKey .Values "global" -}}
-      {{- $globalFullNameOverride = (default $globalFullNameOverride .Values.global.fullnameOverride) -}}
-    {{- end -}}
-    {{- if contains $name .Release.Name -}}
+    {{- if .Values.global.fullNameOverride -}}
+      {{- $name = .Values.global.fullnameOverride -}}
+    {{- else if contains $name .Release.Name -}}
       {{- $name = .Release.Name -}}
     {{- else -}}
       {{- $name = printf "%s-%s" .Release.Name $name -}}

--- a/charts/replicated-library/templates/lib/_names.tpl
+++ b/charts/replicated-library/templates/lib/_names.tpl
@@ -18,7 +18,7 @@ If release name contains chart name it will be used as a full name.
     {{- with .ObjectValues.values -}}
       {{- $values = . -}}
     {{- end -}}
-  {{ end -}}
+  {{- end -}}
 
   {{- if $values.nameOverride -}}
     {{- trunc 63 $values.nameOverride | trimSuffix "-" -}}

--- a/charts/replicated-library/templates/lib/_pod.tpl
+++ b/charts/replicated-library/templates/lib/_pod.tpl
@@ -3,8 +3,8 @@ The pod definition included in the main.
 */ -}}
 {{- define "replicated-library.pod" -}}
   {{- $values := . -}}
-  {{- if hasKey . "AppValues" -}}
-    {{- with .AppValues.app -}}
+  {{- if hasKey . "ObjectValues" -}}
+    {{- with .ObjectValues.values -}}
       {{- $values = . -}}
     {{- end -}}
   {{ end -}}

--- a/charts/replicated-library/templates/lib/_pod_annotations.tpl
+++ b/charts/replicated-library/templates/lib/_pod_annotations.tpl
@@ -2,7 +2,7 @@
 {{- define "replicated-library.podAnnotations" -}}
   {{- $values := . -}}
   {{- if hasKey . "ObjectValues" -}}
-    {{- with .ObjectValues.configmaps -}}
+    {{- with .ObjectValues.values -}}
       {{- $values = . -}}
     {{- end -}}
   {{ end -}}

--- a/charts/replicated-library/templates/lib/_probes.tpl
+++ b/charts/replicated-library/templates/lib/_probes.tpl
@@ -3,8 +3,8 @@ Probes selection logic.
 */}}
 {{- define "replicated-library.probes" -}}
   {{- $values := .Values.probes -}}
-  {{- if hasKey . "AppValues" -}}
-    {{- with .AppValues.app -}}
+  {{- if hasKey . "ObjectValues" -}}
+    {{- with .ObjectValues.values -}}
       {{- $values = . -}}
     {{- end -}}
   {{ end -}}

--- a/charts/replicated-library/templates/lib/_pvc.tpl
+++ b/charts/replicated-library/templates/lib/_pvc.tpl
@@ -12,7 +12,7 @@ Renders the Persistent Volume Claim objects required by the chart.
         {{- $_ := set $ "ObjectName" $persistenceValues.nameOverride -}}
       {{ end -}}
 
-      {{- $_ := set $ "ObjectValues" (dict "persistence" $values) -}}
+      {{- $_ := set $ "ObjectValues" (dict "values" $values) -}}
 
       {{- include "replicated-library.classes.pvc" $ | nindent 0 -}}
     {{- end }}

--- a/charts/replicated-library/templates/lib/_secret.tpl
+++ b/charts/replicated-library/templates/lib/_secret.tpl
@@ -12,7 +12,7 @@ Renders the Secret objects required by the chart.
         {{- $_ := set $ "ObjectName" $secretValues.nameOverride -}}
       {{ end -}}
 
-      {{- $_ := set $ "ObjectValues" (dict "secret" $secretValues) -}}
+      {{- $_ := set $ "ObjectValues" (dict "values" $secretValues) -}}
 
       {{- include "replicated-library.classes.secret" $ | nindent 0 }}
     {{- end }}

--- a/charts/replicated-library/templates/lib/_service.tpl
+++ b/charts/replicated-library/templates/lib/_service.tpl
@@ -12,7 +12,7 @@ Renders the Service objects required by the chart.
         {{- $_ := set $ "ObjectName" $serviceValues.nameOverride -}}
       {{ end -}}
 
-      {{- $_ := set $ "ObjectValues" (dict "service" $serviceValues) -}}
+      {{- $_ := set $ "ObjectValues" (dict "values" $serviceValues) -}}
 
       {{- include "replicated-library.classes.service" $ | nindent 0 }}
     {{- end }}

--- a/charts/replicated-library/templates/lib/_serviceaccount.tpl
+++ b/charts/replicated-library/templates/lib/_serviceaccount.tpl
@@ -3,8 +3,8 @@ The ServiceAccount object to be created.
 */}}
 {{- define "replicated-library.serviceAccount" }}
   {{- $values := .Values.serviceAccount -}}
-  {{- if hasKey . "AppValues" -}}
-    {{- with .AppValues.app -}}
+  {{- if hasKey . "ObjectValues" -}}
+    {{- with .ObjectValues.values -}}
       {{- $values = . -}}
     {{- end -}}
   {{ end -}}

--- a/charts/replicated-library/values.yaml
+++ b/charts/replicated-library/values.yaml
@@ -3,7 +3,7 @@ global:
   labels: {}
   # -- Set additional global annotations.
   annotations: {}
-  # -- Set the entire name definition
+  # -- Set the full object prefix, defaults to releasName-ChartName if not set. This value takes precedence over nameOverride.
   fullNameOverride:
   # -- Set an override for the prefix of the fullname
   nameOverride:

--- a/charts/replicated-library/values.yaml
+++ b/charts/replicated-library/values.yaml
@@ -3,8 +3,10 @@ global:
   labels: {}
   # -- Set additional global annotations.
   annotations: {}
-  fullnameOverride: ""
-  nameOverride: ""
+  # -- Set the entire name definition
+  fullnameOverride:
+  # -- Set an override for the prefix of the fullname
+  nameOverride:
 
 defaults:
   image:
@@ -42,6 +44,9 @@ apps:
      # Valid options are deployment, daemonset or statefulset
      # TODO: daemonset and statefulset
     type: deployment
+
+    # -- Override the name of this object. Default name if not overwritten will be releaseName-ChartName-objectName
+    fullNameOverride:
 
     # -- Set the replica count. Only used for deployment and statefulset
     replicas: 1
@@ -219,8 +224,8 @@ secrets:
     # -- configMap data content. Helm template enabled.
     data: {}
       # foo: bar
-    # -- Override the name suffix that is used for this secret
-    nameOverride:
+    # -- Override the name of this object. Default name if not overwritten will be releaseName-ChartName-objectName
+    fullNameOverride:
 
 # -- Configure the configmaps for the chart here.
 # Configmaps can be added by adding a dictionary key similar to the 'exampleConfig' configmap.
@@ -239,8 +244,8 @@ configmaps:
     # -- configMap data content. Helm template enabled.
     data: {}
       # foo: bar
-    # -- Override the name suffix that is used for this configap
-    nameOverride:
+    # -- Override the name of this object. Default name if not overwritten will be releaseName-ChartName-objectName
+    fullNameOverride:
 
 # -- Configure the services for the chart here.
 # Services can be added by adding a dictionary key similar to the 'example' service.
@@ -255,8 +260,8 @@ services:
     # TODO: Accept a list of appnames of which to associate the service
     # TODO: Needs to be optional
     appName: example
-        # -- Override the name suffix that is used for this service
-    nameOverride:
+    # -- Override the name of this object. Default name if not overwritten will be releaseName-ChartName-objectName
+    fullNameOverride:
     # -- Set the service type
     type: ClusterIP
     # -- Set the clusterIP
@@ -307,8 +312,8 @@ ingresses:
     enabled: false
     # -- Name of the service to attach this ingress. This corresponds to an service configured un the `services` key
     serviceName: example
-    # -- Override the name that is used for this ingress. By default the name will be the name of the dictionary key
-    nameOverride:
+    # -- Override the name of this object. Default name if not overwritten will be releaseName-ChartName-objectName
+    fullNameOverride:
     # -- Provide additional annotations which may be required.
     annotations: {}
     # -- Provide additional labels which may be required.
@@ -344,9 +349,8 @@ persistence:
     # TODO: type.persistentVolume not implemented
     type: persistentVolumeClaim
 
-    # -- Override the name that is used for this persistence object
-    # TODO: NOT IMPLEMENTED
-    nameOverride:
+    # -- Override the name of this object. Default name if not overwritten will be releaseName-ChartName-objectName
+    fullNameOverride:
 
     # -- Configure a persistentVolume and persistentVolumeClaim pair to be mounted to the app's primary container
     # TODO: Not implemented

--- a/charts/replicated-library/values.yaml
+++ b/charts/replicated-library/values.yaml
@@ -4,7 +4,7 @@ global:
   # -- Set additional global annotations.
   annotations: {}
   # -- Set the entire name definition
-  fullnameOverride:
+  fullNameOverride:
   # -- Set an override for the prefix of the fullname
   nameOverride:
 

--- a/charts/replicated-library/values.yaml
+++ b/charts/replicated-library/values.yaml
@@ -3,6 +3,8 @@ global:
   labels: {}
   # -- Set additional global annotations.
   annotations: {}
+  fullnameOverride: ""
+  nameOverride: ""
 
 defaults:
   image:

--- a/charts/replicated-library/values.yaml
+++ b/charts/replicated-library/values.yaml
@@ -5,7 +5,7 @@ global:
   annotations: {}
   # -- Set the full object prefix, defaults to releasName-ChartName if not set. This value takes precedence over nameOverride.
   fullNameOverride:
-  # -- Set an override for the prefix of the fullname
+  # -- Set an override for the ChartName, defaults to ChartName if not set.
   nameOverride:
 
 defaults:


### PR DESCRIPTION
* Prefixes the ReleaseName and/or ChartName to objects created
* A `fullNameOverride` value is available both globally and on each object in order to override the name
* Tracking the the object name and values with `$.ObjectName` and `$.ObjectValues` where before it was named differently in places and inconsistent. 
* Dynamic names per release is the default behavior. 