### PR TITLE
Fix some statefulset errors

### DIFF
--- a/charts/replicated-library/templates/lib/_statefulset.tpl
+++ b/charts/replicated-library/templates/lib/_statefulset.tpl
@@ -63,21 +63,11 @@ spec:
       {{- include "replicated-library.pod" . | nindent 6 }}
   {{- if $values.volumeClaimTemplates }}
   volumeClaimTemplates:
-     {{- range $index, $vct := $values.volumeClaimTemplates }}
-     - metadata:
-         name: {{ $vct.name }}
-       spec:
-         {{- $accessModes := $vct.accessModes | required (printf "accessModes is required, not found on %v" $vct.name) }}
-         accessModes:
-         {{- range $accessModes }}
-           - {{ . }}
-         {{- end }}
-         resources:
-           requests:
-             storage: {{ required (printf "storage is required for volumeClaimTemplate %v" $vct.name) $vct.storage | quote }}
-         {{- if $vct.storageClass }}
-         storageClassName: {{ if (eq "-" $vct.storageClass) }}""{{- else }}{{ $vct.storageClass | quote }}{{- end }}
-        {{- end }}
-    {{- end }}
+  {{- range $name, $vct := $values.volumeClaimTemplates }}
+  - metadata:
+      name: {{ $name }}
+    spec:
+      {{- toYaml $vct.spec | nindent 6 }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/replicated-library/templates/lib/_statefulset.tpl
+++ b/charts/replicated-library/templates/lib/_statefulset.tpl
@@ -2,7 +2,7 @@
 This template serves as the blueprint for the StatefulSet objects that are created
 within the replicated library.
 */}}
-{{- define "replicated-library.servicefor" -}}
+{{- define "replicated-library.firstservice" -}}
   {{- $appName := include "replicated-library.names.appname" . }}
   {{- $matchingServices := list }}
   {{- range $name, $values := .Values.services }}
@@ -47,7 +47,7 @@ spec:
   selector:
     matchLabels:
       {{- include "replicated-library.labels.selectorLabels" . | nindent 6 }}
-  serviceName: {{ default (include "replicated-library.servicefor" .) ($values.serviceName) }}
+  serviceName: {{ default (include "replicated-library.firstservice" .) ($values.serviceName) }}
   template:
     metadata:
       {{- with include ("replicated-library.podAnnotations") . }}


### PR DESCRIPTION
* fix for serviceName malformed templating
* serviceName default set to first service referencing the application
* make persistentVolumeClaimTemplate optional
* fix missing template key
* make persistentVolumeClaimTemplate accessModes accept list
* switch persistentVolumeClaimTemplate size key to storage to match the spec

I'm torn on the format of persistentVolumeClaimTemplate. I made changes to make the inputs match the name of the actual spec, but it's still defining it's own custom format. The only way for people to know what the keys are is if we document it or people read the template. Should we just accept a spec as yaml and pass it through as yaml like we do in the persistence api?

The current implementation is less indention and provides feedback for missing keys. However, you can't copy/paste from the persistance api into the persistanetVolumeClaimTemplate b/c it doesn't actually match the upstream format. I think I prefer, even if it's more verbose, having our `spec` field 100% match upstream so there's no custom formatting. The spec is the spec, and any examples or upstream documentation you find is applicable.