### PR TITLE
Automatically add prefix to persistent volumes

### DIFF
--- a/charts/replicated-library/Chart.yaml
+++ b/charts/replicated-library/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: replicated-library
 description: Replicated library chart
 type: library
-version: 0.5.2
+version: 0.5.3
 kubeVersion: ">=1.16.0-0"
 keywords:
   - replicated-library

--- a/charts/replicated-library/README.md
+++ b/charts/replicated-library/README.md
@@ -1,6 +1,6 @@
 # replicated-library
 
-![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 0.5.3](https://img.shields.io/badge/Version-0.5.3-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 Replicated library chart
 
@@ -37,7 +37,7 @@ Include the chart as a dependency in your `Chart.yaml`
 dependencies:
 - name: replicated-library
   repository: https://replicatedhq.github.io/helm-charts
-  version: 0.5.2
+  version: 0.5.3
 ```
 
 You can see an example of this library chart in use [here](https://github.com/replicatedhq/replicated-starter-helm/tree/replicated-library-chart)
@@ -108,7 +108,7 @@ Read through the [values.yaml](./values.yaml) file. It has several commented out
 | apps.example.topologySpreadConstraints | list | `[]` | Defines topologySpreadConstraint rules. [[ref]](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) |
 | apps.example.type | string | `"deployment"` | Specify the controller type. Valid options are deployment, daemonset or statefulset TODO: daemonset and statefulset |
 | apps.example.volumeClaimTemplates | list | `[]` | Used to create individual disks for each instance when type: StatefulSet |
-| apps.example.volumes | list | `[]` | Specify a list of volumes that get mounted to the app. |
+| apps.example.volumes | list | `[]` | Specify a list of volumes that get mounted to the app. persistentVolumeClaims which are present and enabled in the persistence configuraiton will have the prefix added automatically. |
 | configmaps | object | See below | Configure the configmaps for the chart here. Configmaps can be added by adding a dictionary key similar to the 'exampleConfig' configmap. By default the name of the configmap will be the name of the dictionary key TODO: nameOverride TODO: Ensure sha annotations on app are working |
 | configmaps.exampleConfig.annotations | object | `{}` | Annotations to add to the configMap |
 | configmaps.exampleConfig.data | object | `{}` | configMap data content. Helm template enabled. |
@@ -182,6 +182,11 @@ All notable changes to this library Helm chart will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [0.5.3]
+#### Added
+
+- Automatically add prefix to Statefulset volumes if it's a volume defined and enabled in the chart
 
 ### [0.5.2]
 #### Added

--- a/charts/replicated-library/README_CHANGELOG.md.gotmpl
+++ b/charts/replicated-library/README_CHANGELOG.md.gotmpl
@@ -10,6 +10,11 @@ All notable changes to this library Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [0.5.3]
+#### Added
+
+- Automatically add prefix to Statefulset volumes if it's a volume defined and enabled in the chart
+
 ### [0.5.2]
 #### Added
 

--- a/charts/replicated-library/templates/lib/_pod.tpl
+++ b/charts/replicated-library/templates/lib/_pod.tpl
@@ -73,7 +73,15 @@ containers:
   {{- include "replicated-library.container" . | nindent 2 }}
   {{- with $values.volumes }}
 volumes:
-    {{- toYaml . | nindent 2 }}
+    {{- range . }} 
+      {{- /* Add the prefix to the claimName if the claim is in the persistence dict and is enabled */}}
+      {{- if and .persistentVolumeClaim .persistentVolumeClaim.claimName }}
+        {{- if and (hasKey $.Values.persistence .persistentVolumeClaim.claimName) (get (get $.Values.persistence .persistentVolumeClaim.claimName) "enabled") }}
+          {{- $_ := set .persistentVolumeClaim "claimName" (printf "%s-%s" (include "replicated-library.names.fullname" $) .persistentVolumeClaim.claimName) }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- toYaml . | nindent 2}}
   {{- end }}
   {{- with $values.hostAliases }}
 hostAliases:

--- a/charts/replicated-library/values.yaml
+++ b/charts/replicated-library/values.yaml
@@ -116,6 +116,7 @@ apps:
     initContainers: {}
 
     # -- Specify a list of volumes that get mounted to the app.
+    # persistentVolumeClaims which are present and enabled in the persistence configuraiton will have the prefix added automatically.
     volumes: []
 
     # -- Set annotations on the deployment/statefulset/daemonset


### PR DESCRIPTION
This adds automatic prefix generation for on persistentVolumeClaims found in pod volumes. If a volume has a persistentVolumeClaim with a claimName that is one of the claims in the persistence api and it's enabled in the persistence api then the prefix is added to the claim name.

This means you can use the name in your pod spec that matches the persistence api and the mapping includes the prefix. If the user overrides the volume to use an existing claim not generated by the chart the prefix won't be added. Even if the existing claim _happens_ to have the same name as one in the persistence api if the one from persistence isn't enabled the prefix still won't be added.

I believe this makes it safe to add the prefix and doesn't block the user overriding to map to any claim they already have even if there is a name collision with the chart defaults.