### PR TITLE
spelling error in _pod_annotations.tpl, line 21 - replicated-library.configmap --> replicated-library.configmaps

### DIFF
--- a/charts/replicated-library/templates/lib/_pod_annotations.tpl
+++ b/charts/replicated-library/templates/lib/_pod_annotations.tpl
@@ -18,6 +18,6 @@
     {{- end -}}
   {{- end -}}
   {{- if $configMapsFound -}}
-    {{- printf "checksum/config: %v" (include ("replicated-library.configmap") . | sha256sum) | nindent 0 -}}
+    {{- printf "checksum/config: %v" (include ("replicated-library.configmaps") . | sha256sum) | nindent 0 -}}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
There is a spelling error in _pod_annotations.tpl file.  

When enable configmap, receive the following error:  
executing "replicated-library.podAnnotations" at <include ("replicated-library.configmap") .>: error calling include: template: no template "replicated-library.configmap" associated with template "gotpl"

When change line 21 to:  "replicated-library.configmaps"; a configmap can render.