### PR TITLE
Davidr add type option for secrets

### DIFF
--- a/charts/replicated-library/Chart.yaml
+++ b/charts/replicated-library/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: replicated-library
 description: Replicated library chart
 type: library
-version: 0.5.1
+version: 0.5.2
 kubeVersion: ">=1.16.0-0"
 keywords:
   - replicated-library

--- a/charts/replicated-library/README.md
+++ b/charts/replicated-library/README.md
@@ -1,6 +1,6 @@
 # replicated-library
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 Replicated library chart
 
@@ -37,7 +37,7 @@ Include the chart as a dependency in your `Chart.yaml`
 dependencies:
 - name: replicated-library
   repository: https://replicatedhq.github.io/helm-charts
-  version: 0.5.0
+  version: 0.5.2
 ```
 
 You can see an example of this library chart in use [here](https://github.com/replicatedhq/replicated-starter-helm/tree/replicated-library-chart)
@@ -182,6 +182,11 @@ All notable changes to this library Helm chart will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [0.5.2]
+#### Added
+
+- added capability to set type of secret.
 
 ### [0.5.1]
 #### Changed

--- a/charts/replicated-library/README_CHANGELOG.md.gotmpl
+++ b/charts/replicated-library/README_CHANGELOG.md.gotmpl
@@ -10,6 +10,11 @@ All notable changes to this library Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [0.5.2]
+#### Added
+
+- added capability to set type of secret.
+
 ### [0.5.1]
 #### Changed
 

--- a/charts/replicated-library/templates/classes/_secret.tpl
+++ b/charts/replicated-library/templates/classes/_secret.tpl
@@ -30,5 +30,5 @@ stringData:
 {{- with $values.data }}
   {{- tpl (toYaml .) $ | nindent 2 }}
 {{- end }}
-type: {{ $values.type}}
+type: {{ $values.type }}
 {{- end }}

--- a/charts/replicated-library/templates/classes/_secret.tpl
+++ b/charts/replicated-library/templates/classes/_secret.tpl
@@ -30,4 +30,5 @@ stringData:
 {{- with $values.data }}
   {{- tpl (toYaml .) $ | nindent 2 }}
 {{- end }}
+type: {{ $values.type}}
 {{- end }}

--- a/charts/replicated-library/values.yaml
+++ b/charts/replicated-library/values.yaml
@@ -226,6 +226,9 @@ secrets:
       # foo: bar
     # -- Override the name of this object. Default name if not overwritten will be releaseName-ChartName-objectName
     fullNameOverride:
+    # option to select secret type; default is Opaque
+    # example: set type: kubernetes.io/tls for secrets that contain tls data.
+    type:
 
 # -- Configure the configmaps for the chart here.
 # Configmaps can be added by adding a dictionary key similar to the 'exampleConfig' configmap.


### PR DESCRIPTION
Draft pull request to add the option to set type of secret 
Ie: ability to set type: kubernetes.io/tls for secrets that contain tls data; if type is not set then will default to Opaque.



