### PR TITLE
Fix automatic prefix on volume mounts

### DIFF
--- a/charts/replicated-library/Chart.yaml
+++ b/charts/replicated-library/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: replicated-library
 description: Replicated library chart
 type: library
-version: 0.6.0
+version: 0.6.1
 kubeVersion: ">=1.16.0-0"
 keywords:
   - replicated-library

--- a/charts/replicated-library/README.md
+++ b/charts/replicated-library/README.md
@@ -1,6 +1,6 @@
 # replicated-library
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 Replicated library chart
 
@@ -37,7 +37,7 @@ Include the chart as a dependency in your `Chart.yaml`
 dependencies:
 - name: replicated-library
   repository: https://replicatedhq.github.io/helm-charts
-  version: 0.6.0
+  version: 0.6.1
 ```
 
 You can see an example of this library chart in use [here](https://github.com/replicatedhq/replicated-starter-helm/tree/replicated-library-chart)
@@ -181,6 +181,11 @@ All notable changes to this library Helm chart will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [0.6.1]
+#### Changed
+
+- Fixed automatic prefix on volumes
 
 ### [0.6.0]
 #### Added

--- a/charts/replicated-library/README_CHANGELOG.md.gotmpl
+++ b/charts/replicated-library/README_CHANGELOG.md.gotmpl
@@ -10,6 +10,11 @@ All notable changes to this library Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [0.6.1]
+#### Changed
+
+- Fixed automatic prefix on volumes
+
 ### [0.6.0]
 #### Added
 

--- a/charts/replicated-library/templates/lib/_pod.tpl
+++ b/charts/replicated-library/templates/lib/_pod.tpl
@@ -77,7 +77,7 @@ volumes:
       {{- /* Add the prefix to the claimName if the claim is in the persistence dict and is enabled */}}
       {{- if and .persistentVolumeClaim .persistentVolumeClaim.claimName }}
         {{- if and (hasKey $.Values.persistence .persistentVolumeClaim.claimName) (get (get $.Values.persistence .persistentVolumeClaim.claimName) "enabled") }}
-          {{- $_ := set .persistentVolumeClaim "claimName" (printf "%s-%s" (include "replicated-library.names.fullname" $) .persistentVolumeClaim.claimName) }}
+          {{- $_ := set .persistentVolumeClaim "claimName" (printf "%s-%s" (include "replicated-library.names.prefix" $) .persistentVolumeClaim.claimName) }}
         {{- end }}
       {{- end }}
     {{- end }}


### PR DESCRIPTION
Volume prefix in pods was using fullname rather than prefix