### PR TITLE
Implement a new use of ObjectValues to fix configmaps

### DIFF
--- a/charts/replicated-library/templates/classes/_configmap.tpl
+++ b/charts/replicated-library/templates/classes/_configmap.tpl
@@ -11,7 +11,7 @@ within the replicated-library library.
   {{ end -}}
 
   {{- if hasKey . "ObjectValues" -}}
-    {{- with .ObjectValues.values -}}
+    {{- with .ObjectValues.configmapValues -}}
       {{- $values = . -}}
     {{- end -}}
   {{ end -}}

--- a/charts/replicated-library/templates/lib/_configmap.tpl
+++ b/charts/replicated-library/templates/lib/_configmap.tpl
@@ -7,9 +7,10 @@ Renders the configmap objects required by the chart.
     {{- if $configmap.enabled -}}
       {{- $configmapValues := $configmap -}}
 
-      {{- $_ := set $ "ObjectValues" (dict "values" $configmapValues) -}}
+      {{- $_ := set $.ObjectValues "configmapValues" $configmapValues -}}
 
       {{- include "replicated-library.classes.configmap" $ | nindent 0 }}
+      {{- $_ := unset $.ObjectValues "configmapValues" -}}
     {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
This is an example of how I believe we need to be using the ObjectValues global dictionary, but I'm making it a draft now because this needs more thought first.