### PR TITLE
fix:InitContainers and fullNameOverride

### DIFF
--- a/charts/replicated-library/README.md
+++ b/charts/replicated-library/README.md
@@ -114,6 +114,10 @@ Read through the [values-example.yaml](./values-example.yaml) file. It has sever
 | configmaps.exampleConfig.enabled | bool | `false` | Enables or disables the configMap |
 | configmaps.exampleConfig.fullNameOverride | string | `nil` | Override the name of this object. Default name if not overwritten will be releaseName-ChartName-objectName |
 | configmaps.exampleConfig.labels | object | `{}` | Labels to add to the configMap |
+| global.annotations | object | `{}` | Set additional global annotations. |
+| global.fullNameOverride | string | `nil` | Set the full object prefix, defaults to releasName-ChartName if not set. This value takes precedence over nameOverride. Set to "-" to disable object name prefixing. |
+| global.labels | object | `{}` | Set additional global labels. |
+| global.nameOverride | string | `nil` | Set an override for the ChartName, defaults to ChartName if not set. |
 | ingresses | object | See below | Configure the ingresses for the chart here. Ingresses can be added by adding a dictionary key similar to the 'example' ingress. Name of the ingress object will be the name of the dictionary key |
 | ingresses.example.annotations | object | `{}` | Provide additional annotations which may be required. |
 | ingresses.example.enabled | bool | `false` | Enables or disables the ingress |
@@ -166,9 +170,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+#### Changed
+
+- The `replicated-library.names.fullname` template will now trim a leading or trailing hyphen to prevent invalid names when the prefix is empty
+
+#### Fixed
+
+- Init containers now work as aspected and follow the same format as containers
+
 ### [0.9.0]
 
-### Changed
+#### Changed
 
 - Adding Global "Context" dictionaries for values and names with unique subkeys per object type to prevent collisions
 - Removing class directory and collapsing all templates into a single directory
@@ -176,19 +188,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [0.8.0]
 
-### Changed
+#### Changed
 
 - Fixed volumeClaimTemplate loop in lib/_statefulset.tpl so metadata.name is rendered correctly.
 - Added daemonset templates
 
 ### [0.7.1]
-### Changed
+#### Changed
 
 - Fix fullNameOverride to work with a null input rather than just an empty string.
 - Remove configmap name override, fixes label errors when configmaps are included.
 
 ### [0.7.0]
-### Changed
+#### Changed
 
 - BREAKING: The `appName` key for services is now an optional list instead of a string. Charts using the previous implementation will need to convert the string into a single entry list which will work as before.
 - Services `selector` now overrides selectors set by `appName`.

--- a/charts/replicated-library/README.md
+++ b/charts/replicated-library/README.md
@@ -58,6 +58,7 @@ Read through the [values-example.yaml](./values-example.yaml) file. It has sever
 | apps.example.affinity | object | `{}` | Defines affinity constraint rules. [[ref]](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
 | apps.example.annotations | object | `{}` | Set annotations on the deployment/statefulset/daemonset |
 | apps.example.automountServiceAccountToken | bool | `true` | Specifies whether a service account token should be automatically mounted. |
+| apps.example.containers | object | `{"example":{"args":[],"command":[],"env":null,"envFrom":[],"image":{"pullPolicy":null,"repository":"nginx","tag":"latest"},"lifecycle":{},"ports":[],"probes":{"livenessProbe":{},"readinessProbe":{},"startupProbe":{}},"resources":{},"securityContext":{},"termination":{"gracePeriodSeconds":null,"messagePath":null,"messagePolicy":null},"volumeMounts":[]}}` | Specify any initContainers here as dictionary items. Each initContainer should have its own key. |
 | apps.example.containers.example.args | list | `[]` | Override the arguments for the container |
 | apps.example.containers.example.command | list | `[]` | Override the command for the container |
 | apps.example.containers.example.env | string | `nil` | Environment variables. Template enabled. Syntax options: DATABASE_USER: USERNAME |
@@ -84,7 +85,7 @@ Read through the [values-example.yaml](./values-example.yaml) file. It has sever
 | apps.example.hostNetwork | bool | `false` | When using hostNetwork make sure you set dnsPolicy to `ClusterFirstWithHostNet` |
 | apps.example.hostname | string | `nil` | Allows specifying explicit hostname setting |
 | apps.example.imagePullSecrets | list | `[]` | Specify one or more image pull secrets for the app |
-| apps.example.initContainers | object | `{}` | Specify any initContainers here as dictionary items. Each initContainer should have its own key. The dictionary item key will determine the order. |
+| apps.example.initContainers | object | `{}` | Specify any initContainers here as dictionary items. Each initContainer should have its own key. The dictionary item key will determine the order. All of the same values from .Values.apps.example.containers are valid here with the exception of probes. |
 | apps.example.labels | object | `{}` | Set labels on the deployment/statefulset/daemonset |
 | apps.example.nodeSelector | object | `{}` | Node selection constraint [[ref]](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) |
 | apps.example.podAnnotations | object | `{}` | Set annotations on the pod |

--- a/charts/replicated-library/README_CHANGELOG.md.gotmpl
+++ b/charts/replicated-library/README_CHANGELOG.md.gotmpl
@@ -12,9 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+#### Changed
+
+- The `replicated-library.names.fullname` template will now trim a leading or trailing hyphen to prevent invalid names when the prefix is empty
+
+#### Fixed
+
+- Init containers now work as aspected and follow the same format as containers
+
 ### [0.9.0]
 
-### Changed 
+#### Changed 
 
 - Adding Global "Context" dictionaries for values and names with unique subkeys per object type to prevent collisions
 - Removing class directory and collapsing all templates into a single directory
@@ -22,19 +30,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [0.8.0]
 
-### Changed 
+#### Changed 
 
 - Fixed volumeClaimTemplate loop in lib/_statefulset.tpl so metadata.name is rendered correctly.
 - Added daemonset templates
 
 ### [0.7.1]
-### Changed
+#### Changed
 
 - Fix fullNameOverride to work with a null input rather than just an empty string.
 - Remove configmap name override, fixes label errors when configmaps are included.
 
 ### [0.7.0]
-### Changed
+#### Changed
 
 - BREAKING: The `appName` key for services is now an optional list instead of a string. Charts using the previous implementation will need to convert the string into a single entry list which will work as before.
 - Services `selector` now overrides selectors set by `appName`.

--- a/charts/replicated-library/templates/lib/_container.tpl
+++ b/charts/replicated-library/templates/lib/_container.tpl
@@ -8,7 +8,7 @@
   {{- end -}}
   {{- $_ := set $.ContextValues "names" (dict "context" "app") -}}
 {{- range $containerName, $containerValues := $values.containers -}}
-- name: {{ default "container" $containerName }}
+- name: {{ printf "%s" $containerName | trunc 63 | trimAll "-" }}
   image: {{ printf "%s:%s" $containerValues.image.repository (default $.Chart.AppVersion ($containerValues.image.tag | toString)) | quote }}
   imagePullPolicy: {{ default $.Values.defaults.image.pullPolicy $containerValues.image.pullPolicy }}
   {{- with $containerValues.command }}

--- a/charts/replicated-library/templates/lib/_init_container.tpl
+++ b/charts/replicated-library/templates/lib/_init_container.tpl
@@ -8,7 +8,7 @@
   {{- end -}}
   {{- $_ := set $.ContextValues "names" (dict "context" "app") -}}
 {{- range $containerName, $containerValues := $values.initContainers -}}
-- name: {{ default "container" $containerName }}
+- name: {{ printf "%s" $containerName | trunc 63 | trimAll "-" }}
   image: {{ printf "%s:%s" $containerValues.image.repository (default $.Chart.AppVersion ($containerValues.image.tag | toString)) | quote }}
   imagePullPolicy: {{ default $.Values.defaults.image.pullPolicy $containerValues.image.pullPolicy }}
   {{- with $containerValues.command }}

--- a/charts/replicated-library/templates/lib/_init_container.tpl
+++ b/charts/replicated-library/templates/lib/_init_container.tpl
@@ -1,0 +1,69 @@
+{{- /* The main container included in the main */ -}}
+{{- define "replicated-library.initContainer" -}}
+  {{- $values := "" -}}
+  {{- if and (hasKey . "ContextValues") (hasKey .ContextValues "app") -}}
+    {{- $values = .ContextValues.app -}}
+  {{- else -}}
+    {{- fail "_init_container.tpl requires the 'app' ContextValues to be set" -}}
+  {{- end -}}
+  {{- $_ := set $.ContextValues "names" (dict "context" "app") -}}
+{{- range $containerName, $containerValues := $values.initContainers -}}
+- name: {{ default "container" $containerName }}
+  image: {{ printf "%s:%s" $containerValues.image.repository (default $.Chart.AppVersion ($containerValues.image.tag | toString)) | quote }}
+  imagePullPolicy: {{ default $.Values.defaults.image.pullPolicy $containerValues.image.pullPolicy }}
+  {{- with $containerValues.command }}
+  command:
+    {{- if kindIs "string" . }}
+    - {{ . }}
+    {{- else }}
+      {{ toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  {{- with $containerValues.args }}
+  args:
+    {{- if kindIs "string" . }}
+    - {{ . }}
+    {{- else }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  {{- with $containerValues.securityContext }}
+  securityContext:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $containerValues.lifecycle }}
+  lifecycle:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- if $containerValues.termination }}
+  {{- with $containerValues.termination.messagePath }}
+  terminationMessagePath: {{ . }}
+  {{- end }}
+  {{- with $containerValues.termination.messagePolicy }}
+  terminationMessagePolicy: {{ . }}
+  {{- end }}
+{{- end }}
+  {{- with $containerValues.env }}
+  env:
+    {{- get (fromYaml (include "replicated-library.env_vars" .)) "env" | toYaml | nindent 4 -}}
+  {{- end }}
+  {{- if or $containerValues.envFrom $containerValues.secret }}
+  envFrom:
+    {{- with $containerValues.envFrom }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  {{- with $containerValues.ports }}
+  ports:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $containerValues.volumeMounts }}
+  volumeMounts:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $containerValues.resources }}
+  resources:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/replicated-library/templates/lib/_names.tpl
+++ b/charts/replicated-library/templates/lib/_names.tpl
@@ -47,7 +47,7 @@ If fullNameOverride is provided on the object it will take precedence over the n
     {{- trunc 63 $values.fullNameOverride | trimSuffix "-" -}}
   {{- else -}}
     {{- $prefix := include "replicated-library.names.prefix" . -}}
-    {{- printf "%s-%s" $prefix $objectName | trunc 63 | trimSuffix "-" -}}
+    {{- printf "%s-%s" $prefix $objectName | trunc 63 | trimAll "-" -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/replicated-library/templates/lib/_pod.tpl
+++ b/charts/replicated-library/templates/lib/_pod.tpl
@@ -52,18 +52,10 @@ enableServiceLinks: {{ $values.enableServiceLinks }}
 terminationGracePeriodSeconds: {{ . }}
   {{- end }}
 {{- end }}
-  {{- if $values.initContainers }}
+{{- if $values.initContainers }}
 initContainers:
-    {{- $initContainers := list }}
-    {{- range $index, $key := (keys $values.initContainers | uniq | sortAlpha) }}
-      {{- $container := get $.Values.initContainers $key }}
-      {{- if not $container.name -}}
-        {{- $_ := set $container "name" $key }}
-      {{- end }}
-      {{- $initContainers = append $initContainers $container }}
-    {{- end }}
-    {{- tpl (toYaml $initContainers) $ | nindent 2 }}
-  {{- end }}
+  {{- include "replicated-library.initContainer" . | nindent 2 }}
+{{- end }}
 containers:
   {{- include "replicated-library.container" . | nindent 2 }}
   {{- with $values.volumes }}
@@ -72,7 +64,7 @@ volumes:
       {{- /* Add the prefix to the claimName if the claim is in the persistence dict and is enabled */}}
       {{- if and .persistentVolumeClaim .persistentVolumeClaim.claimName }}
         {{- if and (hasKey $.Values.persistence .persistentVolumeClaim.claimName) (get (get $.Values.persistence .persistentVolumeClaim.claimName) "enabled") }}
-          {{- $_ := set .persistentVolumeClaim "claimName" (printf "%s-%s" (include "replicated-library.names.prefix" $) .persistentVolumeClaim.claimName) }}
+          {{- $_ := set .persistentVolumeClaim "claimName" (printf "%s-%s" (include "replicated-library.names.prefix" $) .persistentVolumeClaim.claimName | trimAll "-") }}
         {{- end }}
       {{- end }}
     {{- end }}

--- a/charts/replicated-library/values-example.yaml
+++ b/charts/replicated-library/values-example.yaml
@@ -1,3 +1,13 @@
+global:
+  # -- Set additional global labels.
+  labels: {}
+  # -- Set additional global annotations.
+  annotations: {}
+  # -- Set the full object prefix, defaults to releasName-ChartName if not set. This value takes precedence over nameOverride.
+  # Set to "-" to disable object name prefixing.
+  fullNameOverride:
+  # -- Set an override for the ChartName, defaults to ChartName if not set.
+  nameOverride:
 
 # -- Configure the apps for the chart here.
 # Apps can be added by adding a dictionary key similar to the 'example' app.

--- a/charts/replicated-library/values-example.yaml
+++ b/charts/replicated-library/values-example.yaml
@@ -32,6 +32,7 @@ apps:
     # -- Specify one or more image pull secrets for the app
     imagePullSecrets: []
 
+    # -- Specify any initContainers here as dictionary items. Each initContainer should have its own key.
     containers:
       example:
         image:
@@ -91,6 +92,7 @@ apps:
 
     # -- Specify any initContainers here as dictionary items. Each initContainer should have its own key.
     # The dictionary item key will determine the order.
+    # All of the same values from .Values.apps.example.containers are valid here with the exception of probes.
     initContainers: {}
 
     # -- Specify a list of volumes that get mounted to the app.

--- a/charts/replicated-library/values.yaml
+++ b/charts/replicated-library/values.yaml
@@ -7,6 +7,7 @@ global:
   # -- Set additional global annotations.
   annotations: {}
   # -- Set the full object prefix, defaults to releasName-ChartName if not set. This value takes precedence over nameOverride.
+  # Set to "-" to disable object name prefixing.
   fullNameOverride:
   # -- Set an override for the ChartName, defaults to ChartName if not set.
   nameOverride:


### PR DESCRIPTION
* Fixes initContainers which have been broken since the chart was forked
* Ensures that leading and trailing hyphens are trimmed from the result of `replicated-library.names.fullname` to ensure that when `global.fullNameOverride` is set to `" "` or  `"-"` that object names are valid. I'm using [trimAll](https://helm.sh/docs/chart_template_guide/function_list/#trimall) to do this.