### PR TITLE
Fixing bug in ImagePullSecrets and Probes

### DIFF
--- a/charts/replicated-library/Chart.yaml
+++ b/charts/replicated-library/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: replicated-library
 description: Replicated library chart
 type: library
-version: 0.11.0
+version: 0.11.1
 kubeVersion: ">=1.16.0-0"
 keywords:
   - replicated-library

--- a/charts/replicated-library/README.md
+++ b/charts/replicated-library/README.md
@@ -1,6 +1,6 @@
 # replicated-library
 
-![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 0.11.1](https://img.shields.io/badge/Version-0.11.1-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 Replicated library chart
 
@@ -37,7 +37,7 @@ Include the chart as a dependency in your `Chart.yaml`
 dependencies:
 - name: replicated-library
   repository: https://replicatedhq.github.io/helm-charts
-  version: 0.11.0
+  version: 0.11.1
 ```
 
 You can see a full example of this library chart in use [here](https://github.com/replicatedhq/replicated-starter-helm/tree/replicated-library-chart)
@@ -178,6 +178,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### [Unreleased]
+
+### [0.11.1]
+
+#### Fixed
+
+- Fixed an issue in YAML formatting that was causing `imagePullSecrets` not to render properly in Pod spec
+- Fixed an issue with the logic to automatically set Readiness and Liveness probes if ports.containerPort is defined
 
 ### [0.11.0]
 

--- a/charts/replicated-library/README_CHANGELOG.md.gotmpl
+++ b/charts/replicated-library/README_CHANGELOG.md.gotmpl
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+### [0.11.1]
+
+#### Fixed
+
+- Fixed an issue in YAML formatting that was causing `imagePullSecrets` not to render properly in Pod spec
+- Fixed an issue with the logic to automatically set Readiness and Liveness probes if ports.containerPort is defined
+
 ### [0.11.0]
 
 #### Changed

--- a/charts/replicated-library/templates/lib/_container.tpl
+++ b/charts/replicated-library/templates/lib/_container.tpl
@@ -70,26 +70,30 @@
   livenessProbe:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- else if hasKey $containerValues "livenessProbe" -}}
-  {{- else if and $containerValues.ports (first $containerValues.ports).containerPort -}}
-  {{- $_ := set $.Values.defaults.probes.livenessProbe "tcpSocket" (dict "port" (first $containerValues.ports).containerPort) }}
-  {{- with $.Values.defaults.probes.livenessProbe }}
+  {{- else if and (hasKey $containerValues "ports") $containerValues.ports -}}
+    {{ $firstPort := first $containerValues.ports }}
+    {{- if and (hasKey $firstPort "containerPort") $firstPort.containerPort -}}
+      {{- $_ := set $.Values.defaults.probes.livenessProbe "tcpSocket" (dict "port" (first $containerValues.ports).containerPort) }}
+      {{- with $.Values.defaults.probes.livenessProbe }}
   livenessProbe:
-    {{- toYaml . | nindent 4 }}
-  {{- end -}}
+      {{- toYaml . | nindent 4 }}
+      {{- end -}}
+    {{- end -}}
   {{- end -}}
   {{- if $containerValues.readinessProbe -}}
   {{- with (mergeOverwrite $.Values.defaults.probes.readinessProbe $containerValues.readinessProbe) }}
   readinessProbe:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- else if hasKey $containerValues "readinessProbe" -}}
-  {{- else if and $containerValues.ports (first $containerValues.ports).containerPort -}}
-  {{- $_ := set $.Values.defaults.probes.readinessProbe "tcpSocket" (dict "port" (first $containerValues.ports).containerPort) }}
-  {{- with $.Values.defaults.probes.readinessProbe }}
+  {{- else if and (hasKey $containerValues "ports") $containerValues.ports -}}
+    {{ $firstPort := first $containerValues.ports }}
+    {{- if and (hasKey $firstPort "containerPort") $firstPort.containerPort -}}
+      {{- $_ := set $.Values.defaults.probes.readinessProbe "tcpSocket" (dict "port" (first $containerValues.ports).containerPort) }}
+      {{- with $.Values.defaults.probes.readinessProbe }}
   readinessProbe:
-    {{- toYaml . | nindent 4 }}
-  {{- end -}}
+      {{- toYaml . | nindent 4 }}
+      {{- end -}}
+    {{- end -}}
   {{- end -}}
   {{- if $containerValues.startupProbe -}}
   {{- with (mergeOverwrite $.Values.defaults.probes.startupProbe $containerValues.startupProbe) }}

--- a/charts/replicated-library/templates/lib/_pod.tpl
+++ b/charts/replicated-library/templates/lib/_pod.tpl
@@ -9,11 +9,10 @@ The pod definition included in the main.
     {{- fail "_pod.tpl requires the 'app' ContextValues to be set" -}}
   {{- end -}}
   {{- $_ := set $.ContextValues "names" (dict "context" "app") -}}
-
   {{- with $values.imagePullSecrets }}
 imagePullSecrets:
     {{- toYaml . | nindent 2 }}
-  {{- end -}}
+  {{- end }}
 serviceAccountName: {{ include "replicated-library.names.serviceAccountName" . }}
 automountServiceAccountToken: {{ $values.automountServiceAccountToken }}
   {{- with $values.podSecurityContext }}


### PR DESCRIPTION
* Fixed an issue in YAML formatting that was causing `imagePullSecrets` not to render properly in Pod spec
* Fixed an issue with the logic to automatically set Readiness and Liveness probes if ports.containerPort is defined