### PR TITLE
Tidy up pod and container whitespace

### DIFF
--- a/charts/replicated-library/Chart.yaml
+++ b/charts/replicated-library/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: replicated-library
 description: Replicated library chart
 type: library
-version: 0.12.1
+version: 0.12.2
 kubeVersion: ">=1.16.0-0"
 keywords:
   - replicated-library

--- a/charts/replicated-library/README_CHANGELOG.md.gotmpl
+++ b/charts/replicated-library/README_CHANGELOG.md.gotmpl
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added capability to override service name for ingress hosts (shortcut story - 71019)
 
+### [0.12.2]
+
+- Tidied up extra whitespace for pod and conatiner templates
 
 ### [0.12.1]
 

--- a/charts/replicated-library/templates/lib/_container.tpl
+++ b/charts/replicated-library/templates/lib/_container.tpl
@@ -7,7 +7,7 @@
     {{- fail "_container.tpl requires the 'app' ContextValues to be set" -}}
   {{- end -}}
   {{- $_ := set $.ContextValues "names" (dict "context" "app") -}}
-{{- range $containerName, $containerValues := $values.containers }}
+{{- range $containerName, $containerValues := $values.containers -}}
 - name: {{ printf "%s" $containerName | trunc 63 | trimAll "-" }}
   image: {{ printf "%s:%s" $containerValues.image.repository (default $.Chart.AppVersion ($containerValues.image.tag | toString)) | quote }}
   imagePullPolicy: {{ default $.Values.defaults.image.pullPolicy $containerValues.image.pullPolicy }}

--- a/charts/replicated-library/templates/lib/_pod.tpl
+++ b/charts/replicated-library/templates/lib/_pod.tpl
@@ -12,7 +12,7 @@ The pod definition included in the main.
   {{- with $values.imagePullSecrets }}
 imagePullSecrets:
     {{- toYaml . | nindent 2 }}
-  {{- end }}
+  {{- end -}}
 serviceAccountName: {{ include "replicated-library.names.serviceAccountName" . }}
 automountServiceAccountToken: {{ $values.automountServiceAccountToken }}
   {{- with $values.podSecurityContext }}


### PR DESCRIPTION
Current pod spec has some extra linebreaks

```
    spec:
      
      serviceAccountName: 
      automountServiceAccountToken: 
      dnsPolicy: ClusterFirst
      enableServiceLinks: 
      containers:
        
        - name: vaultwarden
          image: "vaultwarden/server:1.27.0-alpine"
          imagePullPolicy: IfNotPresent
```

This PR tidies them up. 

```
    spec:
      serviceAccountName: 
      automountServiceAccountToken: 
      dnsPolicy: ClusterFirst
      enableServiceLinks: 
      containers:
        - name: vaultwarden
          image: "vaultwarden/server:1.27.0-alpine"
          imagePullPolicy: IfNotPresent
```
