### PR TITLE
Make RBAC roles for preflights optional

### DIFF
--- a/charts/replicated-library/Chart.yaml
+++ b/charts/replicated-library/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: replicated-library
 description: Replicated library chart
 type: library
-version: 0.13.3
+version: 0.13.4
 kubeVersion: ">=1.16.0-0"
 keywords:
   - replicated-library

--- a/charts/replicated-library/README.md
+++ b/charts/replicated-library/README.md
@@ -1,6 +1,6 @@
 # replicated-library
 
-![Version: 0.13.3](https://img.shields.io/badge/Version-0.13.3-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 0.13.4](https://img.shields.io/badge/Version-0.13.4-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 Replicated library chart
 
@@ -39,7 +39,7 @@ Include the chart as a dependency in your `Chart.yaml`
 dependencies:
 - name: replicated-library
   repository: https://replicatedhq.github.io/helm-charts
-  version: 0.13.3
+  version: 0.13.4
 ```
 
 You can see a full example of this library chart in use [here](https://github.com/replicatedhq/replicated-starter-helm)
@@ -64,6 +64,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### [Unreleased]
+
+### [0.13.4]
+
+#### Added
+
+- Make RBAC for preflights optional
 
 ### [0.13.3]
 

--- a/charts/replicated-library/README_CHANGELOG.md.gotmpl
+++ b/charts/replicated-library/README_CHANGELOG.md.gotmpl
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+### [0.13.4]
+
+#### Added
+
+- Make RBAC for preflights optional
+
 ### [0.13.3]
 
 #### Fixed

--- a/charts/replicated-library/templates/lib/_preflights.tpl
+++ b/charts/replicated-library/templates/lib/_preflights.tpl
@@ -38,6 +38,7 @@ stringData:
         {{- fail (printf "Preflight %s requires the analyzers to be set" .ContextNames.troubleshoot) }}
       {{- end }}
 
+{{ if $values.enableRBAC -}}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -136,6 +137,7 @@ roleRef:
   name: {{ $.Release.Name }}-preflight-{{ .ContextNames.troubleshoot }}
   apiGroup: rbac.authorization.k8s.io
 
+{{- end -}}
 ---
 apiVersion: v1
 kind: Pod
@@ -151,7 +153,9 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
     "helm.sh/hook-output-log-policy": hook-failed, hook-succeeded
 spec:
+{{- if $values.enableRBAC }}
   serviceAccountName: {{ $.Release.Name }}-preflight-{{ .ContextNames.troubleshoot }}
+{{- end }}
   restartPolicy: Never
   volumes:
     - name: preflights

--- a/charts/replicated-library/values-example.yaml
+++ b/charts/replicated-library/values-example.yaml
@@ -497,7 +497,10 @@ troubleshoot:
       # -- Specify the replicated preflight image for the container
       image: replicated/preflight:latest
       # -- Enables or disables the preflight
-      enabled: true
+      enabled: false
+      # -- Enable or disable the creation of RBAC roles to run the preflight
+      enableRBAC: false
+      # -- Add collectors and analyzers here
       collectors:
         - run:
             collectorName: "static-hi"


### PR DESCRIPTION
To cope with restricted environments, the creation of RBAC roles/bindings for preflight checks in the pre-install hook is now optional, default off.