### PR TITLE
feat: add switch to disable pre-install hooks

### DIFF
--- a/charts/replicated-library/templates/lib/_preflights.tpl
+++ b/charts/replicated-library/templates/lib/_preflights.tpl
@@ -136,6 +136,7 @@ roleRef:
   name: {{ $.Release.Name }}-preflight-{{ .ContextNames.troubleshoot }}
   apiGroup: rbac.authorization.k8s.io
 
+{{- if $values.runHook -}}
 ---
 apiVersion: v1
 kind: Pod
@@ -167,5 +168,6 @@ spec:
       volumeMounts:
         - name: preflights
           mountPath: /preflights
+{{- end -}}
 
 {{- end }}

--- a/charts/replicated-library/values-example.yaml
+++ b/charts/replicated-library/values-example.yaml
@@ -498,6 +498,8 @@ troubleshoot:
       image: replicated/preflight:latest
       # -- Enables or disables the preflight
       enabled: true
+      # -- Enable or disable the preflight running in a pre-install/pre-upgrade hook
+      runHook: false
       collectors:
         - run:
             collectorName: "static-hi"


### PR DESCRIPTION
By default, preflight checks do not run as pre-install hooks, but a new runHook switch enables that.