### PR TITLE
Fix container env variable to allow use of secrets and configMaps

### DIFF
--- a/charts/replicated-library/templates/lib/_container.tpl
+++ b/charts/replicated-library/templates/lib/_container.tpl
@@ -43,25 +43,16 @@
   terminationMessagePolicy: {{ . }}
   {{- end }}
 {{- end }}
-
-
-
-  {{- with $containerValues.env }}
+{{- with $containerValues.env }}
   env:
     {{- get (fromYaml (include "replicated-library.env_vars" .)) "env" | toYaml | nindent 4 -}}
-  {{- end }}
-
+{{- end }}
   {{- with $containerValues.env }}
   env:
     {{- with $containerValues.env}}
       {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- end }}
-
-
-
-
-
   {{- if or $containerValues.envFrom $containerValues.secret }}
   envFrom:
     {{- with $containerValues.envFrom }}

--- a/charts/replicated-library/templates/lib/_container.tpl
+++ b/charts/replicated-library/templates/lib/_container.tpl
@@ -43,10 +43,25 @@
   terminationMessagePolicy: {{ . }}
   {{- end }}
 {{- end }}
+
+
+
   {{- with $containerValues.env }}
   env:
     {{- get (fromYaml (include "replicated-library.env_vars" .)) "env" | toYaml | nindent 4 -}}
   {{- end }}
+
+  {{- with $containerValues.env }}
+  env:
+    {{- with $containerValues.env}}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+
+
+
+
+
   {{- if or $containerValues.envFrom $containerValues.secret }}
   envFrom:
     {{- with $containerValues.envFrom }}


### PR DESCRIPTION
This is in reference to [issue #99](https://github.com/replicatedhq/helm-charts/issues/99)

This fix allows use of local env variables set in container config and also allow use of secrets and configMaps in the following manner:

```
<img width="696" alt="image" src="https://github.com/replicatedhq/helm-charts/assets/30049377/733ef355-56d7-4f22-b032-81c5391b9d17">

```

<img width="497" alt="image" src="https://github.com/replicatedhq/helm-charts/assets/30049377/fbf8d603-24ec-4ec0-979a-7ea227ea227b">
