### PR TITLE
Cleaning up template errors

### DIFF
--- a/charts/replicated-library/templates/_all.tpl
+++ b/charts/replicated-library/templates/_all.tpl
@@ -20,4 +20,11 @@ Main entrypoint for the replicated-library chart. It will render all underlying 
   {{ include "replicated-library.roles" . | nindent 0 }}
   {{ include "replicated-library.roleBindings" . | nindent 0 }}
   {{ include "replicated-library.troubleshoot" . | nindent 0 }}
+
+  {{- if len $.ContextNames -}}
+  {{- fail "$.ContextNames is not empty" -}}
+  {{- end -}}
+  {{- if len $.ContextValues -}}
+  {{- fail "$.ContextValues is not empty" -}}
+  {{- end -}}
 {{- end -}}

--- a/charts/replicated-library/templates/_all.tpl
+++ b/charts/replicated-library/templates/_all.tpl
@@ -21,10 +21,12 @@ Main entrypoint for the replicated-library chart. It will render all underlying 
   {{ include "replicated-library.roleBindings" . | nindent 0 }}
   {{ include "replicated-library.troubleshoot" . | nindent 0 }}
 
+  {{/* Uncomment when all fails are removed
   {{- if len $.ContextNames -}}
   {{- fail "$.ContextNames is not empty" -}}
   {{- end -}}
   {{- if len $.ContextValues -}}
   {{- fail "$.ContextValues is not empty" -}}
   {{- end -}}
+  */}}
 {{- end -}}

--- a/charts/replicated-library/templates/lib/_apps.tpl
+++ b/charts/replicated-library/templates/lib/_apps.tpl
@@ -20,6 +20,7 @@ Renders the app objects into Deployments, DaemonSets, and StatefulSets as requir
 
       {{- $_ := unset $.ContextNames "app"  -}}
       {{- $_ := unset $.ContextValues "app"  -}}
+      {{- $_ := unset $.ContextValues "names"  -}}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/replicated-library/templates/lib/_container.tpl
+++ b/charts/replicated-library/templates/lib/_container.tpl
@@ -6,8 +6,8 @@
   {{- else -}}
     {{- fail "_container.tpl requires the 'app' ContextValues to be set" -}}
   {{- end -}}
-  {{- $_ := set $.ContextValues "names" (dict "context" "app") -}}
-{{- range $containerName, $containerValues := $values.containers -}}
+  {{- $_ := set $.ContextValues "names" (dict "context" "app") }}
+{{- range $containerName, $containerValues := $values.containers }}
 - name: {{ printf "%s" $containerName | trunc 63 | trimAll "-" }}
   image: {{ printf "%s:%s" $containerValues.image.repository (default $.Chart.AppVersion ($containerValues.image.tag | toString)) | quote }}
   imagePullPolicy: {{ default $.Values.defaults.image.pullPolicy $containerValues.image.pullPolicy }}
@@ -45,7 +45,7 @@
 {{- end }}
   {{- with $containerValues.env }}
   env:
-       {{- get (fromYaml (include "replicated-library.env_vars" .)) "env" | toYaml | nindent 4 -}}
+       {{- get (fromYaml (include "replicated-library.env_vars" .)) "env" | toYaml | nindent 4 }}
   {{- end }}
   {{- if or $containerValues.envFrom $containerValues.secret }}
   envFrom:
@@ -65,41 +65,41 @@
   resources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- if $containerValues.livenessProbe -}}
+  {{- if $containerValues.livenessProbe }}
   {{- with (mergeOverwrite $.Values.defaults.probes.livenessProbe $containerValues.livenessProbe) }}
   livenessProbe:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- else if and (hasKey $containerValues "ports") $containerValues.ports -}}
+  {{- else if and (hasKey $containerValues "ports") $containerValues.ports }}
     {{ $firstPort := first $containerValues.ports }}
-    {{- if and (hasKey $firstPort "containerPort") $firstPort.containerPort -}}
+    {{- if and (hasKey $firstPort "containerPort") $firstPort.containerPort }}
       {{- $_ := set $.Values.defaults.probes.livenessProbe "tcpSocket" (dict "port" (first $containerValues.ports).containerPort) }}
       {{- with $.Values.defaults.probes.livenessProbe }}
   livenessProbe:
       {{- toYaml . | nindent 4 }}
-      {{- end -}}
-    {{- end -}}
-  {{- end -}}
-  {{- if $containerValues.readinessProbe -}}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- if $containerValues.readinessProbe }}
   {{- with (mergeOverwrite $.Values.defaults.probes.readinessProbe $containerValues.readinessProbe) }}
   readinessProbe:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- else if and (hasKey $containerValues "ports") $containerValues.ports -}}
+  {{- else if and (hasKey $containerValues "ports") $containerValues.ports }}
     {{ $firstPort := first $containerValues.ports }}
-    {{- if and (hasKey $firstPort "containerPort") $firstPort.containerPort -}}
+    {{- if and (hasKey $firstPort "containerPort") $firstPort.containerPort }}
       {{- $_ := set $.Values.defaults.probes.readinessProbe "tcpSocket" (dict "port" (first $containerValues.ports).containerPort) }}
       {{- with $.Values.defaults.probes.readinessProbe }}
   readinessProbe:
       {{- toYaml . | nindent 4 }}
-      {{- end -}}
-    {{- end -}}
-  {{- end -}}
-  {{- if $containerValues.startupProbe -}}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- if $containerValues.startupProbe }}
   {{- with (mergeOverwrite $.Values.defaults.probes.startupProbe $containerValues.startupProbe) }}
   startupProbe:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- end -}}
+  {{- end }}
 {{- end }}
-{{- end -}}
+{{- end }}

--- a/charts/replicated-library/templates/lib/_deployment.tpl
+++ b/charts/replicated-library/templates/lib/_deployment.tpl
@@ -59,5 +59,5 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- include "replicated-library.pod" . | nindent 6 }}
+      {{- include "replicated-library.pod" . | trim | nindent 6 }}
 {{- end }}

--- a/charts/replicated-library/templates/lib/_deployment.tpl
+++ b/charts/replicated-library/templates/lib/_deployment.tpl
@@ -21,8 +21,12 @@ metadata:
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if $values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ $values.revisionHistoryLimit }}
+  {{- end }}
+  {{- if $values.replicas }}
   replicas: {{ $values.replicas }}
+  {{- end }}
   {{- $strategy := default $.Values.defaults.strategy $values.strategy }}
   {{- if and (ne $strategy "Recreate") (ne $strategy "RollingUpdate") }}
     {{- fail (printf "Not a valid strategy type for Deployment (%s)" $strategy) }}

--- a/charts/replicated-library/templates/lib/_labels.tpl
+++ b/charts/replicated-library/templates/lib/_labels.tpl
@@ -19,6 +19,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- define "replicated-library.labels.selectorLabels" -}}
 {{- $_ := set $.ContextValues "names" (dict "context" "app") -}}
 app.kubernetes.io/name: {{ include "replicated-library.names.appname" . }}
+{{- $_ := unset $.ContextValues "names" }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- define "replicated-library.labels.serviceSelectorLabels" -}}
@@ -28,7 +29,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   {{- else -}}
     {{- fail "_labels.tpl requires the 'service' ContextValues to be set" -}}
   {{- end -}}
-  {{- $_ := set $.ContextValues "names" (dict "context" "service") -}}
   {{- if $values.selector -}}
 {{ toYaml $values.selector }}
   {{- else -}}

--- a/charts/replicated-library/templates/lib/_pod.tpl
+++ b/charts/replicated-library/templates/lib/_pod.tpl
@@ -9,7 +9,7 @@ The pod definition included in the main.
     {{- fail "_pod.tpl requires the 'app' ContextValues to be set" -}}
   {{- end -}}
   {{- $_ := set $.ContextValues "names" (dict "context" "app") -}}
-  {{- with $values.imagePullSecrets -}}
+  {{- with $values.imagePullSecrets }}
 imagePullSecrets:
     {{- toYaml . | nindent 2 }}
   {{- end }}

--- a/charts/replicated-library/templates/lib/_pod.tpl
+++ b/charts/replicated-library/templates/lib/_pod.tpl
@@ -63,7 +63,7 @@ initContainers:
   {{- include "replicated-library.initContainer" . | nindent 2 }}
 {{- end }}
 containers:
-  {{- include "replicated-library.container" . | nindent 2 }}
+  {{- include "replicated-library.container" . | trim | nindent 2 }}
   {{- with $values.volumes }}
 volumes:
     {{- range . }} 

--- a/charts/replicated-library/templates/lib/_pod.tpl
+++ b/charts/replicated-library/templates/lib/_pod.tpl
@@ -8,7 +8,6 @@ The pod definition included in the main.
   {{- else -}}
     {{- fail "_pod.tpl requires the 'app' ContextValues to be set" -}}
   {{- end -}}
-  {{- $_ := set $.ContextValues "names" (dict "context" "app") -}}
   {{- with $values.imagePullSecrets }}
 imagePullSecrets:
     {{- toYaml . | nindent 2 }}

--- a/charts/replicated-library/templates/lib/_pod.tpl
+++ b/charts/replicated-library/templates/lib/_pod.tpl
@@ -9,7 +9,7 @@ The pod definition included in the main.
     {{- fail "_pod.tpl requires the 'app' ContextValues to be set" -}}
   {{- end -}}
   {{- $_ := set $.ContextValues "names" (dict "context" "app") -}}
-  {{- with $values.imagePullSecrets }}
+  {{- with $values.imagePullSecrets -}}
 imagePullSecrets:
     {{- toYaml . | nindent 2 }}
   {{- end }}

--- a/charts/replicated-library/templates/lib/_service.tpl
+++ b/charts/replicated-library/templates/lib/_service.tpl
@@ -9,14 +9,15 @@ within the replicated-library library.
   {{- else -}}
     {{- fail "_service.tpl requires the 'service' ContextValues to be set" -}}
   {{- end -}}
-  {{- $_ := set $.ContextValues "names" (dict "context" "service") -}}
 
   {{- $svcType := $values.type | default "" -}}
 ---
 apiVersion: v1
 kind: Service
 metadata:
+  {{- $_ := set $.ContextValues "names" (dict "context" "service") }}
   name: {{ include "replicated-library.names.fullname" . }}
+  {{- $_ := unset $.ContextValues "names"  }}
   {{- with (merge ($values.labels | default dict) (include "replicated-library.labels" $ | fromYaml)) }}
   labels: {{- toYaml . | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
Currently includes:
* Added the check for leftover contexts back in 
* Unset a leftover context in _apps template
* Put optional parameters in deployment template behind an if statement to avoid blank settings
* trim the pod include statement to remove an unnecessary new line on deployments
* Correct the use of set/unset in pod template 