### PR TITLE
Make app.serviceAccountName work as intended

### DIFF
--- a/charts/replicated-library/Chart.yaml
+++ b/charts/replicated-library/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: replicated-library
 description: Replicated library chart
 type: library
-version: 0.13.6
+version: 0.13.7
 kubeVersion: ">=1.16.0-0"
 keywords:
   - replicated-library

--- a/charts/replicated-library/README.md
+++ b/charts/replicated-library/README.md
@@ -1,6 +1,6 @@
 # replicated-library
 
-![Version: 0.13.6](https://img.shields.io/badge/Version-0.13.2-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 0.13.7](https://img.shields.io/badge/Version-0.13.7-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 Replicated library chart
 
@@ -39,7 +39,7 @@ Include the chart as a dependency in your `Chart.yaml`
 dependencies:
 - name: replicated-library
   repository: https://replicatedhq.github.io/helm-charts
-  version: 0.13.6
+  version: 0.13.7
 ```
 
 You can see a full example of this library chart in use [here](https://github.com/replicatedhq/replicated-starter-helm)
@@ -56,163 +56,6 @@ Below highlights some of the useful features available in this library
 
 [Examples of how you can advanced templating and build on top of this library chart](ADVANCED_TEMPLATING.md)
 
-## Values
-
-The below table represents the full API available via the Replicated Library Chart with `example` being a placeholder for your own configuration. Source is [values-example.yaml](./values-example.yaml) file.
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| apps | object | See below | Configure the apps for the chart here. Apps can be added by adding a dictionary key similar to the 'example' app. By default the name of the app will be the name of the dictionary key TODO: nameOverride TODO: Ensure sha annotations on app are working |
-| apps.example.affinity | object | `{}` | Defines affinity constraint rules. [[ref]](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
-| apps.example.annotations | object | `{}` | Set annotations on the deployment/statefulset/daemonset |
-| apps.example.automountServiceAccountToken | bool | `true` | Specifies whether a service account token should be automatically mounted. |
-| apps.example.containers | object | `{"example":{"args":[],"command":[],"env":null,"envFrom":[],"image":{"pullPolicy":null,"repository":"nginx","tag":"latest"},"lifecycle":{},"ports":[],"probes":{"livenessProbe":{},"readinessProbe":{},"startupProbe":{}},"resources":{},"securityContext":{},"termination":{"gracePeriodSeconds":null,"messagePath":null,"messagePolicy":null},"volumeMounts":[]}}` | Specify any initContainers here as dictionary items. Each initContainer should have its own key. |
-| apps.example.containers.example.args | list | `[]` | Override the arguments for the container |
-| apps.example.containers.example.command | list | `[]` | Override the command for the container |
-| apps.example.containers.example.env | string | `nil` | Environment variables. Template enabled. Syntax options: DATABASE_USER: USERNAME |
-| apps.example.containers.example.envFrom | list | `[]` | Secrets and/or ConfigMaps that will be loaded as environment variables. [[ref]](https://unofficial-kubernetes.readthedocs.io/en/latest/tasks/configure-pod-container/configmap/#use-case-consume-configmap-in-environment-variables) |
-| apps.example.containers.example.image.pullPolicy | string | `nil` | Specify the image pull policy for the container |
-| apps.example.containers.example.image.repository | string | `"nginx"` | Specify the image repository for the container |
-| apps.example.containers.example.image.tag | string | `"latest"` | Specify the image tag for the container |
-| apps.example.containers.example.lifecycle | object | `{}` | Configure the lifecycle for the container |
-| apps.example.containers.example.ports | list | `[]` | Specify the ports for the container [[ref]](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#ports) |
-| apps.example.containers.example.probes | object | `{"livenessProbe":{},"readinessProbe":{},"startupProbe":{}}` | Specify probes for the container [[ref]](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) |
-| apps.example.containers.example.probes.livenessProbe | object | `{}` | Specify the liveness probes for the container |
-| apps.example.containers.example.probes.readinessProbe | object | `{}` | Specify the readiness probes for the container |
-| apps.example.containers.example.probes.startupProbe | object | `{}` | Specify the startup probes for the container |
-| apps.example.containers.example.resources | object | `{}` | Set the resource requests / limits for the container. |
-| apps.example.containers.example.termination.gracePeriodSeconds | string | `nil` | [[ref](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#lifecycle)] |
-| apps.example.containers.example.termination.messagePath | string | `nil` | [[ref](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#lifecycle-1)] |
-| apps.example.containers.example.termination.messagePolicy | string | `nil` | [[ref](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#lifecycle-1)] |
-| apps.example.containers.example.volumeMounts | list | `[]` | Specify a list of volumes mounts in the container. |
-| apps.example.dnsConfig | object | `{}` | Optional DNS settings, configuring the ndots option may resolve nslookup issues on some Kubernetes setups. |
-| apps.example.dnsPolicy | string | `nil` | Defaults to "ClusterFirst" if hostNetwork is false and "ClusterFirstWithHostNet" if hostNetwork is true. |
-| apps.example.enableServiceLinks | bool | `true` | Enable/disable the generation of environment variables for services. [[ref]](https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#accessing-the-service) |
-| apps.example.enabled | bool | `false` | Enable the app Each app represents a single controller type (deployment, daemonset, statefulset) |
-| apps.example.hostAliases | list | `[]` | Use hostAliases to add custom entries to /etc/hosts - mapping IP addresses to hostnames. [[ref]](https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/) |
-| apps.example.hostNetwork | bool | `false` | When using hostNetwork make sure you set dnsPolicy to `ClusterFirstWithHostNet` |
-| apps.example.hostname | string | `nil` | Allows specifying explicit hostname setting |
-| apps.example.imagePullSecrets | list | `[]` | Specify one or more image pull secrets for the app |
-| apps.example.initContainers | object | `{}` | Specify any initContainers here as dictionary items. Each initContainer should have its own key. The dictionary item key will determine the order. All of the same values from .Values.apps.example.containers are valid here with the exception of probes. |
-| apps.example.labels | object | `{}` | Set labels on the deployment/statefulset/daemonset |
-| apps.example.nodeSelector | object | `{}` | Node selection constraint [[ref]](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) |
-| apps.example.podAnnotations | object | `{}` | Set annotations on the pod |
-| apps.example.podLabels | object | `{}` | Set labels on the pod |
-| apps.example.podManagementPolicy | string | `nil` | Set statefulset podManagementPolicy, valid values are Parallel and OrderedReady (default). |
-| apps.example.podSecurityContext | object | `{}` | Configure the Security Context for the Pod |
-| apps.example.priorityClassName | string | `nil` | Custom priority class for different treatment by the scheduler |
-| apps.example.replicas | int | `1` | Set the replica count. Only used for deployment and statefulset |
-| apps.example.revisionHistoryLimit | int | `3` | ReplicaSet revision history limit |
-| apps.example.rollingUpdate.partition | string | `nil` | Set statefulset RollingUpdate partition |
-| apps.example.rollingUpdate.surge | string | `nil` | Set deployment RollingUpdate max surge |
-| apps.example.rollingUpdate.unavailable | string | `nil` | Set deployment RollingUpdate max unavailable |
-| apps.example.runtimeClassName | string | `nil` | Allow specifying a runtimeClassName other than the default one (ie: nvidia) |
-| apps.example.schedulerName | string | `nil` | Allows specifying a custom scheduler name |
-| apps.example.strategy | string | `nil` | Set the controller upgrade strategy For Deployments, valid values are Recreate and RollingUpdate. For StatefulSets, valid values are OnDelete and RollingUpdate. For Daemonsets, valid values are OnDelete and RollingUpdate. |
-| apps.example.tolerations | list | `[]` | Specify taint tolerations [[ref]](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) |
-| apps.example.topologySpreadConstraints | list | `[]` | Defines topologySpreadConstraint rules. [[ref]](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) |
-| apps.example.type | string | `"deployment"` | Specify the controller type. Valid options are deployment, daemonset or statefulset |
-| apps.example.volumeClaimTemplates | list | `[]` | Used to create individual disks for each instance when type: StatefulSet |
-| apps.example.volumes | list | `[]` | Specify a list of volumes that get mounted to the app. persistentVolumeClaims which are present and enabled in the persistence configuraiton will have the prefix added automatically. |
-| configmaps | object | See below | Configure the configmaps for the chart here. Configmaps can be added by adding a dictionary key similar to the 'exampleConfig' configmap. By default the name of the configmap will be the name of the dictionary key TODO: nameOverride TODO: Ensure sha annotations on app are working |
-| configmaps.exampleConfig.annotations | object | `{}` | Annotations to add to the configMap |
-| configmaps.exampleConfig.appReload | bool | `true` | When `true`, the feature to automatically re-deploy an App's pod when the ConfigMap changes is enabled. |
-| configmaps.exampleConfig.data | object | `{}` | configMap data content. Helm template enabled. |
-| configmaps.exampleConfig.enabled | bool | `false` | Enables or disables the configMap |
-| configmaps.exampleConfig.fullNameOverride | string | `nil` | Override the name of this object. Default name if not overwritten will be releaseName-ChartName-objectName |
-| configmaps.exampleConfig.labels | object | `{}` | Labels to add to the configMap |
-| global.annotations | object | `{}` | Set additional global annotations. |
-| global.appReload | bool | `true` | When `true`, the feature to automatically re-deploy an App's pod when a ConfigMap or Secret changes is enabled. |
-| global.fullNameOverride | string | `nil` | Set the full object prefix, defaults to releasName-ChartName if not set. This value takes precedence over nameOverride. Set to "-" to disable object name prefixing. |
-| global.labels | object | `{}` | Set additional global labels. |
-| global.nameOverride | string | `nil` | Set an override for the ChartName, defaults to ChartName if not set. |
-| ingresses | object | See below | Configure the ingresses for the chart here. Ingresses can be added by adding a dictionary key similar to the 'example' ingress. Name of the ingress object will be the name of the dictionary key |
-| ingresses.example.annotations | object | `{}` | Provide additional annotations |
-| ingresses.example.enabled | bool | `false` | Enables or disables the ingress |
-| ingresses.example.fullNameOverride | string | `nil` | Override the name of this object. Default name if not overwritten will be releaseName-ChartName-objectName |
-| ingresses.example.hosts | list | `[{"host":"chart-example.local","paths":[{"path":"/","pathType":"Prefix","service":{"name":null,"port":null}}]}]` | Configure the hosts for the ingress |
-| ingresses.example.hosts[0].paths[0].service.name | string | `nil` | Service Name for the path. By default this is ingresses.example.serviceName if not overwritten TODO: NOT IMPLEMENTED |
-| ingresses.example.ingressClassName | string | `nil` | Set the ingressClass that is used for this ingress. Requires Kubernetes >=1.19 |
-| ingresses.example.labels | object | `{}` | Provide additional labels |
-| ingresses.example.serviceName | string | `"example"` | Name of the service to attach this ingress. This corresponds to an service configured un the `services` key |
-| persistence | object | See below | Configure volumes for the chart here. Persistence items can be added by adding a dictionary key similar to the 'example' key. Name of the persistence object will be the name of the dictionary key unless overwritten with persistence.*.nameOverride |
-| persistence.example.enabled | bool | `false` | Enables or disables the volume |
-| persistence.example.fullNameOverride | string | `nil` | Override the name of this object. Default name if not overwritten will be releaseName-ChartName-objectName |
-| persistence.example.persistentVolume | object | `{"spec":{"accessModes":["ReadWriteOnce"],"capacity":{"storage":"1Gi"},"hostPath":{"path":"/tmp/data1"},"reclaimPolicy":["Recycle"]}}` | Configure a persistentVolume and persistentVolumeClaim pair to be mounted to the app's primary container TODO: Not implemented |
-| persistence.example.persistentVolume.spec | object | `{"accessModes":["ReadWriteOnce"],"capacity":{"storage":"1Gi"},"hostPath":{"path":"/tmp/data1"},"reclaimPolicy":["Recycle"]}` | PersistentVolumeClaim spec [[ref]](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) |
-| persistence.example.persistentVolumeClaim | object | `{"existingClaimName":null,"spec":{"accessModes":["ReadWriteOnce"],"persistentVolumeReclaimPolicy":"Retain","resources":{"requests":{"storage":"8Gi"}},"storageClassName":"slow","volumeMode":"Filesystem"}}` | Configure a Persistent Volume Claim to be mounted to the app's primary container |
-| persistence.example.persistentVolumeClaim.existingClaimName | string | `nil` | Existing Persistent Volume Claim name. Takes precedence over persistentVolumeClaim.spec |
-| persistence.example.persistentVolumeClaim.spec | object | `{"accessModes":["ReadWriteOnce"],"persistentVolumeReclaimPolicy":"Retain","resources":{"requests":{"storage":"8Gi"}},"storageClassName":"slow","volumeMode":"Filesystem"}` | PersistentVolumeClaim spec [[ref]](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims) |
-| persistence.example.type | string | `"persistentVolumeClaim"` | Volume type. Available options are ["persistentVolume," "persistentVolumeClaim"] type.persistentVolume creates a PV and a PVC pair and uses the PVC as a volume on the app type.persistentVolumeClaim creates a new PVC or uses an existing PVC as a volume on the app TODO: type.persistentVolume not implemented |
-| roleBindings | object | See below | Configure the roleBindings for the chart here. RoleBindings can be added by adding a dictionary key similar to the 'example' roleBinding. By default the name of the roleBinding will be the name of the dictionary key unless overridden with roleBindings.*.nameOverride |
-| roleBindings.example.annotations | object | `{}` | Annotations to add to the clusterRole |
-| roleBindings.example.enabled | bool | `false` | Enables or disables the roleBinding |
-| roleBindings.example.fullNameOverride | string | `nil` | Override the name of this object. Default name if not overwritten will be releaseName-ChartName-objectName |
-| roleBindings.example.kind | string | `"RoleBinding"` | Type of roleBinding. Must be either: ["RoleBinding", "ClusterRoleBinding"] |
-| roleBindings.example.labels | object | `{}` | Labels to add to the clusterRole |
-| roleBindings.example.roleRef | object | `{"kind":"Role","name":"example"}` | The Role to bind to the ServiceAccount |
-| roleBindings.example.roleRef.kind | string | `"Role"` | Type of roleBinding. Must be either: ["RoleBinding", "ClusterRoleBinding"].  If the roleBinding is a ClusterRoleBinding, then roleRef.kind must be set to ClusterRole |
-| roleBindings.example.roleRef.name | string | `"example"` | Name of the Role to bind to subjects.  If roleRef.kind: is set to ClusterRoleBinding, then name must be the name of a ClusterRole |
-| roleBindings.example.subjects | list | `[{"kind":"ServiceAccount","name":"example","namespace":null}]` | Name of the service account to bind to the role |
-| roleBindings.example.subjects[0] | object | `{"kind":"ServiceAccount","name":"example","namespace":null}` | Name of the service account to bind to the role |
-| roleBindings.example.subjects[0].kind | string | `"ServiceAccount"` | Kind of the service account to bind to the role.  Optional.  Defaults to ServiceAccount.  Must be one of: ["ServiceAccount", "User", "Group"].  Currently, only ServiceAccount is supported. |
-| roles | object | See below | Configure the roles for the chart here. Roles can be added by adding a dictionary key similar to the 'example' role. By default the name of the role will be the name of the dictionary key unless overridden with roles.*.nameOverride TODO: implement aggregated ClusterRoles |
-| roles.example.aggregationRule | object | `{}` | Define the selectors used for aggregated ClusterRoles.  Only used with ClusterRoles. |
-| roles.example.annotations | object | `{}` | Annotations to add to the role |
-| roles.example.enabled | bool | `false` | Enables or disables the role |
-| roles.example.fullNameOverride | string | `nil` | Override the name of this object. Default name if not overwritten will be releaseName-ChartName-objectName |
-| roles.example.kind | string | `"Role"` | Type of role. Must be either: ["Role", "ClusterRole"] |
-| roles.example.labels | object | `{}` | Labels to add to the role |
-| roles.example.rules | list | `[]` | Configure the rules for the role |
-| secrets | object | See below | Configure the secrets for the chart here. Secrets can be added by adding a dictionary key similar to the 'exampleSecret' secret. By default the name of the secret will be the name of the dictionary key TODO: nameOverride TODO: Ensure sha annotations on app are working |
-| secrets.exampleSecret.annotations | object | `{}` | Annotations to add to the secret |
-| secrets.exampleSecret.appReload | bool | `true` | When `true`, the feature to automatically re-deploy an App's pod when the Secret changes is enabled. |
-| secrets.exampleSecret.data | object | `{}` | configMap data content. Helm template enabled. |
-| secrets.exampleSecret.enabled | bool | `false` | Enables or disables the secret |
-| secrets.exampleSecret.fullNameOverride | string | `nil` | Override the name of this object. Default name if not overwritten will be releaseName-ChartName-objectName |
-| secrets.exampleSecret.labels | object | `{}` | Labels to add to the secret |
-| serviceAccounts | object | See below | Configure the serviceAccounts for the chart here. ServiceAccounts can be added by adding a dictionary key similar to the 'example' serviceAccount. By default the name of the serviceAccount will be the name of the dictionary key unless overridden with serviceAccounts.*.nameOverride |
-| serviceAccounts.example.annotations | object | `{}` | Annotations to add to the service account |
-| serviceAccounts.example.enabled | bool | `false` | Enables or disables the service account |
-| serviceAccounts.example.fullNameOverride | string | `nil` | Override the name of this object. Default name if not overwritten will be releaseName-ChartName-objectName |
-| serviceAccounts.example.labels | object | `{}` | Labels to add to the service account |
-| services | object | See below | Configure the services for the chart here. Services can be added by adding a dictionary key similar to the 'example' service. By default the name of the service will be the name of the dictionary key TODO: nameOverride |
-| services.example.annotations | object | `{}` | Provide additional annotations which may be required. |
-| services.example.appName | list | `["example"]` | Optional list of apps to attach this service. This corresponds to apps configured in the `apps` key |
-| services.example.clusterIP | string | `nil` | Set the clusterIP To deploy a headless service, set clusterIP: "None" |
-| services.example.enabled | bool | `false` | Enables or disables the service |
-| services.example.externalTrafficPolicy | string | `nil` | [[ref](https://kubernetes.io/docs/tutorials/services/source-ip/)] |
-| services.example.fullNameOverride | string | `nil` | Override the name of this object. Default name if not overwritten will be releaseName-ChartName-objectName |
-| services.example.ipFamilies | list | `[]` | The ip families that should be used. Options: IPv4, IPv6 |
-| services.example.ipFamilyPolicy | string | `nil` | Specify the ip policy. Options: SingleStack, PreferDualStack, RequireDualStack |
-| services.example.labels | object | `{}` | Provide additional labels which may be required. |
-| services.example.ports | object | See below | Configure the Service port information here. Additional ports can be added by adding a dictionary key similar to the 'http' service. |
-| services.example.ports.http.enabled | bool | `true` | Enables or disables the port |
-| services.example.ports.http.nodePort | string | `nil` | Specify the nodePort value for the LoadBalancer and NodePort service types. [[ref]](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport) |
-| services.example.ports.http.port | string | `nil` | The port number |
-| services.example.ports.http.protocol | string | `"HTTP"` | Port protocol. Support values are `HTTP`, `HTTPS`, `TCP` and `UDP`. HTTPS and HTTPS spawn a TCP service and get used for internal URL and name generation |
-| services.example.ports.http.targetPort | string | `nil` | Specify a service targetPort if you wish to differ the service port from the application port. If `targetPort` is specified, this port number is used in the container definition instead of the `port` value. Therefore named ports are not supported for this field. |
-| services.example.selector | object | `{}` | Label sleector(s) for the service to associate Pods as Endpoints. This takes precedence over services.*.appName |
-| services.example.type | string | `"ClusterIP"` | Set the service type |
-| troubleshoot | object | `{"preflights":{"my-preflights":{"analyzers":[{"textAnalyze":{"checkName":"Said hi!","fileName":"/static-hi.log","outcomes":[{"fail":{"message":"Didn't say hi."}},{"pass":{"message":"Said hi!"}}],"regex":"hi static"}}],"collectors":[{"run":{"collectorName":"static-hi","command":["echo","hi static!"],"image":"alpine:3"}}],"enabled":true,"image":"replicated/preflight:latest"}},"support-bundles":{"replicated":{"enabled":true,"my-custom-bundle":{"collectors":[{"clusterInfo":{}},{"clusterResources":{}},{"ceph":{}},{"longhorn":{}},{"logs":{"collectorName":"example","containerNames":["example"],"namespace":"default","selector":{"app":"example"}}},{"logs":{"appName":"example","name":"example"}},{"logs":{"appName":"*","name":"all"}},{"logs":{"collectorName":"some-postgres-db","selector":{"app":"some-postgres-db"}}},{"configMap":{"configMapName":"example-configmap","includeAllData":true,"namespace":"default"}},{"configMap":{"configMapName":"*","includeAllData":true}},{"secret":{"key":".dockerconfigjson","namespace":"default","secretName":"example-secret-registry"}},{"secret":{"secretName":"*"}}],"enabled":true},"uri":"https://raw.githubusercontent.com/replicatedhq/troubleshoot-specs/main/in-cluster/default.yaml"}}}` | Configure the troubleshoot for the chart here. troubleshoot can be added by adding a dictionary key. By default the supportBundle default spec from replicated will be disabled and not installed |
-| troubleshoot.preflights.my-preflights | object | `{"analyzers":[{"textAnalyze":{"checkName":"Said hi!","fileName":"/static-hi.log","outcomes":[{"fail":{"message":"Didn't say hi."}},{"pass":{"message":"Said hi!"}}],"regex":"hi static"}}],"collectors":[{"run":{"collectorName":"static-hi","command":["echo","hi static!"],"image":"alpine:3"}}],"enabled":true,"image":"replicated/preflight:latest"}` | Add custom support preflight spec here |
-| troubleshoot.preflights.my-preflights.enabled | bool | `true` | Enables or disables the preflight |
-| troubleshoot.preflights.my-preflights.image | string | `"replicated/preflight:latest"` | Specify the replicated preflight image for the container |
-| troubleshoot.support-bundles | object | `{"replicated":{"enabled":true,"my-custom-bundle":{"collectors":[{"clusterInfo":{}},{"clusterResources":{}},{"ceph":{}},{"longhorn":{}},{"logs":{"collectorName":"example","containerNames":["example"],"namespace":"default","selector":{"app":"example"}}},{"logs":{"appName":"example","name":"example"}},{"logs":{"appName":"*","name":"all"}},{"logs":{"collectorName":"some-postgres-db","selector":{"app":"some-postgres-db"}}},{"configMap":{"configMapName":"example-configmap","includeAllData":true,"namespace":"default"}},{"configMap":{"configMapName":"*","includeAllData":true}},{"secret":{"key":".dockerconfigjson","namespace":"default","secretName":"example-secret-registry"}},{"secret":{"secretName":"*"}}],"enabled":true},"uri":"https://raw.githubusercontent.com/replicatedhq/troubleshoot-specs/main/in-cluster/default.yaml"}}` | Specify the type of troubleshoot, Preflight or SupportBundle |
-| troubleshoot.support-bundles.replicated.enabled | bool | `true` | Enables or disables the support bundle |
-| troubleshoot.support-bundles.replicated.my-custom-bundle | object | `{"collectors":[{"clusterInfo":{}},{"clusterResources":{}},{"ceph":{}},{"longhorn":{}},{"logs":{"collectorName":"example","containerNames":["example"],"namespace":"default","selector":{"app":"example"}}},{"logs":{"appName":"example","name":"example"}},{"logs":{"appName":"*","name":"all"}},{"logs":{"collectorName":"some-postgres-db","selector":{"app":"some-postgres-db"}}},{"configMap":{"configMapName":"example-configmap","includeAllData":true,"namespace":"default"}},{"configMap":{"configMapName":"*","includeAllData":true}},{"secret":{"key":".dockerconfigjson","namespace":"default","secretName":"example-secret-registry"}},{"secret":{"secretName":"*"}}],"enabled":true}` | Add custom support bundles here |
-| troubleshoot.support-bundles.replicated.my-custom-bundle.collectors[10].secret.namespace | string | `"default"` | Define namespace where the secret exists or leave blank for the current namespace of helm release |
-| troubleshoot.support-bundles.replicated.my-custom-bundle.collectors[10].secret.secretName | string | `"example-secret-registry"` | Simply use the exact name of secret for the secretName generated by this chart or another external configMap |
-| troubleshoot.support-bundles.replicated.my-custom-bundle.collectors[11].secret.secretName | string | `"*"` | Use the wildcard *, if you wish to select all secrets generated by this chart |
-| troubleshoot.support-bundles.replicated.my-custom-bundle.collectors[5].logs.appName | string | `"example"` | Simply use the exact name of application for the appName. |
-| troubleshoot.support-bundles.replicated.my-custom-bundle.collectors[6].logs.appName | string | `"*"` | Use the wildcard *, if you wish to select all applications generated by this chart |
-| troubleshoot.support-bundles.replicated.my-custom-bundle.collectors[8].configMap.configMapName | string | `"example-configmap"` | Simply use the exact name of configMap generated by this chart or another external configMap |
-| troubleshoot.support-bundles.replicated.my-custom-bundle.collectors[8].configMap.namespace | string | `"default"` | Define namespace where the ConfigMap exists |
-| troubleshoot.support-bundles.replicated.my-custom-bundle.collectors[9].configMap.configMapName | string | `"*"` | Use the wildcard *, if you wish to select all configMaps generated by this chart |
-| troubleshoot.support-bundles.replicated.my-custom-bundle.collectors[9].configMap.includeAllData | bool | `true` | Current namespace of helm release will be the default namespace for the ConfigMap to collect, if you don't specify a namespace |
-| troubleshoot.support-bundles.replicated.uri | string | `"https://raw.githubusercontent.com/replicatedhq/troubleshoot-specs/main/in-cluster/default.yaml"` | Default spec to install |
-
->>>>>>> 8f7f548 (feat(replicated-library): update values-example.yaml for appName, secretName, configMapName usage)
 ## Changelog
 
 All notable changes to this library Helm chart will be documented in this file.
@@ -222,11 +65,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
-### [0.13.6]
+### [0.13.7]
 
 #### Added
 
-- Update Troubleshoot collectors to select a default namespace if not specified
+- Remove unused app.serviceAccount
+- Setup app.serviceAccountName to configure which serviceAccount an app uses
 
 ### [0.13.5]
 
@@ -256,9 +100,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Fixed
 
 - Fixed issue where whitespace was being chomped and causing formatting issue with imagePullSecrets
-#### Added
-
-- Added capability to override service name for ingress hosts (shortcut story - 71019)
 
 ### [0.13.2]
 

--- a/charts/replicated-library/README_CHANGELOG.md.gotmpl
+++ b/charts/replicated-library/README_CHANGELOG.md.gotmpl
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+### [0.13.7]
+
+#### Added
+
+- Remove unused app.serviceAccount
+- Setup app.serviceAccountName to configure which serviceAccount an app uses
+
 ### [0.13.5]
 
 #### Added

--- a/charts/replicated-library/templates/lib/_apps.tpl
+++ b/charts/replicated-library/templates/lib/_apps.tpl
@@ -18,11 +18,6 @@ Renders the app objects into Deployments, DaemonSets, and StatefulSets as requir
         {{- fail (printf "Type of (%s) for app - (%s) is not valid" $appValues.type $name) }}
       {{ end -}}
 
-      {{- if $appValues.serviceAccount -}}
-        {{- if $appValues.serviceAccount.create -}}
-          {{- include "replicated-library.serviceAccount" $ }}
-        {{- end }}
-      {{- end }}
       {{- $_ := unset $.ContextNames "app"  -}}
       {{- $_ := unset $.ContextValues "app"  -}}
     {{- end }}

--- a/charts/replicated-library/templates/lib/_pod.tpl
+++ b/charts/replicated-library/templates/lib/_pod.tpl
@@ -13,7 +13,15 @@ The pod definition included in the main.
 imagePullSecrets:
     {{- toYaml . | nindent 2 }}
   {{- end }}
-serviceAccountName: {{ include "replicated-library.names.serviceAccountName" . }}
+  {{- if $values.serviceAccountName }}
+    {{- /* Add the prefix to the serviceAccountName if it is in the serviceAccounts dict and is enabled */}}
+      {{- if $.Values.serviceAccounts }}
+        {{- if and (hasKey $.Values.serviceAccounts $values.serviceAccountName) (get (get $.Values.serviceAccounts $values.serviceAccountName) "enabled") -}}
+          {{- $_ := set $values "serviceAccountName" (printf "%s-%s" (include "replicated-library.names.prefix" $) $values.serviceAccountName | trimAll "-") }}
+        {{- end }}
+      {{- end }}
+serviceAccountName: {{ $values.serviceAccountName }}
+  {{- end }}
 automountServiceAccountToken: {{ $values.automountServiceAccountToken }}
   {{- with $values.podSecurityContext }}
 securityContext:


### PR DESCRIPTION
Addresses #104 

Input: 
```yaml
apps:
  outline:
    imagePullSecrets:
      foo: bar
    serviceAccountName: barfoo
    enabled: true
    type: deployment
    containers:
      outline:
        image:
          repository: outlinewiki/outline
          tag: 0.70.2
```
Output:
```yaml
---
# Source: outline/templates/replicated-library.tpl
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-outline-outline
  labels:
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: outline
    app.kubernetes.io/version: "1"
    helm.sh/chart: outline-0.0.1
spec:
  revisionHistoryLimit:
  replicas:
  strategy:
    type: RollingUpdate
  selector:
    matchLabels:
      app.kubernetes.io/name: outline
      app.kubernetes.io/instance: release-name
  template:
    metadata:
      labels:
        app.kubernetes.io/name: outline
        app.kubernetes.io/instance: release-name
    spec:

      imagePullSecrets:
        foo: bar
      serviceAccountName: barfoo
      automountServiceAccountToken:
      dnsPolicy: ClusterFirst
      enableServiceLinks:
      containers:
        - name: outline
          image: "outlinewiki/outline:0.70.2"
          imagePullPolicy: IfNotPresent
```

Input:
```yaml
apps:
  outline:
    imagePullSecrets:
      foo: bar
    serviceAccountName: barfoo
    enabled: true
    type: deployment
    containers:
      outline:
        image:
          repository: outlinewiki/outline
          tag: 0.70.2
serviceAccounts:
  barfoo:
    enabled: true
```

Output:
```yaml
---
# Source: outline/templates/replicated-library.tpl
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-outline-outline
  labels:
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: outline
    app.kubernetes.io/version: "1"
    helm.sh/chart: outline-0.0.1
spec:
  revisionHistoryLimit:
  replicas:
  strategy:
    type: RollingUpdate
  selector:
    matchLabels:
      app.kubernetes.io/name: outline
      app.kubernetes.io/instance: release-name
  template:
    metadata:
      labels:
        app.kubernetes.io/name: outline
        app.kubernetes.io/instance: release-name
    spec:

      imagePullSecrets:
        foo: bar
      serviceAccountName: release-name-outline-barfoo
      automountServiceAccountToken:
      dnsPolicy: ClusterFirst
      enableServiceLinks:
      containers:
        - name: outline
          image: "outlinewiki/outline:0.70.2"
          imagePullPolicy: IfNotPresent
```

